### PR TITLE
feat: class system definitions (Warrior, Mage, Rogue)

### DIFF
--- a/src/game/classes/classes.test.ts
+++ b/src/game/classes/classes.test.ts
@@ -3,88 +3,88 @@ import { CLASS_DEFINITIONS, getClassDefinition } from "./data"
 import type { CharacterClassId } from "./types"
 
 describe("CLASS_DEFINITIONS", () => {
-  it("defines exactly 3 classes", () => {
-    expect(Object.keys(CLASS_DEFINITIONS)).toHaveLength(3)
-  })
+	it("defines exactly 3 classes", () => {
+		expect(Object.keys(CLASS_DEFINITIONS)).toHaveLength(3)
+	})
 
-  it("has warrior, mage, and rogue", () => {
-    expect(CLASS_DEFINITIONS).toHaveProperty("warrior")
-    expect(CLASS_DEFINITIONS).toHaveProperty("mage")
-    expect(CLASS_DEFINITIONS).toHaveProperty("rogue")
-  })
+	it("has warrior, mage, and rogue", () => {
+		expect(CLASS_DEFINITIONS).toHaveProperty("warrior")
+		expect(CLASS_DEFINITIONS).toHaveProperty("mage")
+		expect(CLASS_DEFINITIONS).toHaveProperty("rogue")
+	})
 })
 
 describe("Warrior", () => {
-  const warrior = CLASS_DEFINITIONS.warrior
+	const warrior = CLASS_DEFINITIONS.warrior
 
-  it("has strength as primary attribute", () => {
-    expect(warrior.primaryAttribute).toBe("strength")
-  })
+	it("has strength as primary attribute", () => {
+		expect(warrior.primaryAttribute).toBe("strength")
+	})
 
-  it("starts with 10 strength, 5 dex, 5 int", () => {
-    expect(warrior.baseStats.attributes).toEqual({
-      strength: 10, dexterity: 5, intelligence: 5,
-    })
-  })
+	it("starts with 10 strength, 5 dex, 5 int", () => {
+		expect(warrior.baseStats.attributes).toEqual({
+			strength: 10, dexterity: 5, intelligence: 5,
+		})
+	})
 
-  it("has 100 base HP", () => {
-    expect(warrior.baseStats.hp).toBe(100)
-  })
+	it("has 100 base HP", () => {
+		expect(warrior.baseStats.hp).toBe(100)
+	})
 
-  it("has 0 base barrier", () => {
-    expect(warrior.baseStats.barrier).toBe(0)
-  })
+	it("has 0 base barrier", () => {
+		expect(warrior.baseStats.barrier).toBe(0)
+	})
 })
 
 describe("Mage", () => {
-  const mage = CLASS_DEFINITIONS.mage
+	const mage = CLASS_DEFINITIONS.mage
 
-  it("has intelligence as primary attribute", () => {
-    expect(mage.primaryAttribute).toBe("intelligence")
-  })
+	it("has intelligence as primary attribute", () => {
+		expect(mage.primaryAttribute).toBe("intelligence")
+	})
 
-  it("starts with 5 strength, 5 dex, 10 int", () => {
-    expect(mage.baseStats.attributes).toEqual({
-      strength: 5, dexterity: 5, intelligence: 10,
-    })
-  })
+	it("starts with 5 strength, 5 dex, 10 int", () => {
+		expect(mage.baseStats.attributes).toEqual({
+			strength: 5, dexterity: 5, intelligence: 10,
+		})
+	})
 
-  it("has 40 base HP", () => {
-    expect(mage.baseStats.hp).toBe(40)
-  })
+	it("has 40 base HP", () => {
+		expect(mage.baseStats.hp).toBe(40)
+	})
 
-  it("has 20 base barrier", () => {
-    expect(mage.baseStats.barrier).toBe(20)
-  })
+	it("has 20 base barrier", () => {
+		expect(mage.baseStats.barrier).toBe(20)
+	})
 })
 
 describe("Rogue", () => {
-  const rogue = CLASS_DEFINITIONS.rogue
+	const rogue = CLASS_DEFINITIONS.rogue
 
-  it("has dexterity as primary attribute", () => {
-    expect(rogue.primaryAttribute).toBe("dexterity")
-  })
+	it("has dexterity as primary attribute", () => {
+		expect(rogue.primaryAttribute).toBe("dexterity")
+	})
 
-  it("starts with 5 strength, 10 dex, 5 int", () => {
-    expect(rogue.baseStats.attributes).toEqual({
-      strength: 5, dexterity: 10, intelligence: 5,
-    })
-  })
+	it("starts with 5 strength, 10 dex, 5 int", () => {
+		expect(rogue.baseStats.attributes).toEqual({
+			strength: 5, dexterity: 10, intelligence: 5,
+		})
+	})
 
-  it("has 60 base HP", () => {
-    expect(rogue.baseStats.hp).toBe(60)
-  })
+	it("has 60 base HP", () => {
+		expect(rogue.baseStats.hp).toBe(60)
+	})
 
-  it("has 0 base barrier", () => {
-    expect(rogue.baseStats.barrier).toBe(0)
-  })
+	it("has 0 base barrier", () => {
+		expect(rogue.baseStats.barrier).toBe(0)
+	})
 })
 
 describe("getClassDefinition", () => {
-  it("returns the correct class for each id", () => {
-    const ids: CharacterClassId[] = ["warrior", "mage", "rogue"]
-    for (const id of ids) {
-      expect(getClassDefinition(id).id).toBe(id)
-    }
-  })
+	it("returns the correct class for each id", () => {
+		const ids: CharacterClassId[] = ["warrior", "mage", "rogue"]
+		for (const id of ids) {
+			expect(getClassDefinition(id).id).toBe(id)
+		}
+	})
 })

--- a/src/game/classes/classes.test.ts
+++ b/src/game/classes/classes.test.ts
@@ -1,0 +1,90 @@
+import { describe, it, expect } from "vitest"
+import { CLASS_DEFINITIONS, getClassDefinition } from "./data"
+import type { CharacterClassId } from "./types"
+
+describe("CLASS_DEFINITIONS", () => {
+  it("defines exactly 3 classes", () => {
+    expect(Object.keys(CLASS_DEFINITIONS)).toHaveLength(3)
+  })
+
+  it("has warrior, mage, and rogue", () => {
+    expect(CLASS_DEFINITIONS).toHaveProperty("warrior")
+    expect(CLASS_DEFINITIONS).toHaveProperty("mage")
+    expect(CLASS_DEFINITIONS).toHaveProperty("rogue")
+  })
+})
+
+describe("Warrior", () => {
+  const warrior = CLASS_DEFINITIONS.warrior
+
+  it("has strength as primary attribute", () => {
+    expect(warrior.primaryAttribute).toBe("strength")
+  })
+
+  it("starts with 10 strength, 5 dex, 5 int", () => {
+    expect(warrior.baseStats.attributes).toEqual({
+      strength: 10, dexterity: 5, intelligence: 5,
+    })
+  })
+
+  it("has 100 base HP", () => {
+    expect(warrior.baseStats.hp).toBe(100)
+  })
+
+  it("has 0 base barrier", () => {
+    expect(warrior.baseStats.barrier).toBe(0)
+  })
+})
+
+describe("Mage", () => {
+  const mage = CLASS_DEFINITIONS.mage
+
+  it("has intelligence as primary attribute", () => {
+    expect(mage.primaryAttribute).toBe("intelligence")
+  })
+
+  it("starts with 5 strength, 5 dex, 10 int", () => {
+    expect(mage.baseStats.attributes).toEqual({
+      strength: 5, dexterity: 5, intelligence: 10,
+    })
+  })
+
+  it("has 40 base HP", () => {
+    expect(mage.baseStats.hp).toBe(40)
+  })
+
+  it("has 20 base barrier", () => {
+    expect(mage.baseStats.barrier).toBe(20)
+  })
+})
+
+describe("Rogue", () => {
+  const rogue = CLASS_DEFINITIONS.rogue
+
+  it("has dexterity as primary attribute", () => {
+    expect(rogue.primaryAttribute).toBe("dexterity")
+  })
+
+  it("starts with 5 strength, 10 dex, 5 int", () => {
+    expect(rogue.baseStats.attributes).toEqual({
+      strength: 5, dexterity: 10, intelligence: 5,
+    })
+  })
+
+  it("has 60 base HP", () => {
+    expect(rogue.baseStats.hp).toBe(60)
+  })
+
+  it("has 0 base barrier", () => {
+    expect(rogue.baseStats.barrier).toBe(0)
+  })
+})
+
+describe("getClassDefinition", () => {
+  it("returns the correct class for each id", () => {
+    const ids: CharacterClassId[] = ["warrior", "mage", "rogue"]
+    for (const id of ids) {
+      expect(getClassDefinition(id).id).toBe(id)
+    }
+  })
+})

--- a/src/game/classes/data.ts
+++ b/src/game/classes/data.ts
@@ -1,41 +1,44 @@
 import type { CharacterClassDefinition, CharacterClassId } from "./types"
 
-export const CLASS_DEFINITIONS: Record<CharacterClassId, CharacterClassDefinition> = {
-  warrior: {
-    id: "warrior",
-    name: "Warrior",
-    description: "A battle-hardened fighter who relies on raw strength and heavy armor to overpower enemies.",
-    primaryAttribute: "strength",
-    baseStats: {
-      hp: 100,
-      barrier: 0,
-      attributes: { strength: 10, dexterity: 5, intelligence: 5 },
-    },
-  },
-  rogue: {
-    id: "rogue",
-    name: "Rogue",
-    description: "A swift and cunning combatant who exploits precision and agility to strike where it hurts most.",
-    primaryAttribute: "dexterity",
-    baseStats: {
-      hp: 60,
-      barrier: 0,
-      attributes: { strength: 5, dexterity: 10, intelligence: 5 },
-    },
-  },
-  mage: {
-    id: "mage",
-    name: "Mage",
-    description: "A wielder of arcane power who sacrifices physical resilience for devastating magical potential and a natural energy barrier.",
-    primaryAttribute: "intelligence",
-    baseStats: {
-      hp: 40,
-      barrier: 20,
-      attributes: { strength: 5, dexterity: 5, intelligence: 10 },
-    },
-  },
-} as const
+export const CLASS_DEFINITIONS = {
+	warrior: {
+		id: "warrior",
+		name: "Warrior",
+		description:
+			"A battle-hardened fighter who relies on raw strength and heavy armor to overpower enemies.",
+		primaryAttribute: "strength",
+		baseStats: {
+			hp: 100,
+			barrier: 0,
+			attributes: { strength: 10, dexterity: 5, intelligence: 5 },
+		},
+	},
+	rogue: {
+		id: "rogue",
+		name: "Rogue",
+		description:
+			"A swift and cunning combatant who exploits precision and agility to strike where it hurts most.",
+		primaryAttribute: "dexterity",
+		baseStats: {
+			hp: 60,
+			barrier: 0,
+			attributes: { strength: 5, dexterity: 10, intelligence: 5 },
+		},
+	},
+	mage: {
+		id: "mage",
+		name: "Mage",
+		description:
+			"A wielder of arcane power who sacrifices physical resilience for devastating magical potential and a natural energy barrier.",
+		primaryAttribute: "intelligence",
+		baseStats: {
+			hp: 40,
+			barrier: 20,
+			attributes: { strength: 5, dexterity: 5, intelligence: 10 },
+		},
+	},
+} as const satisfies Record<CharacterClassId, CharacterClassDefinition>
 
 export function getClassDefinition(id: CharacterClassId): CharacterClassDefinition {
-  return CLASS_DEFINITIONS[id]
+	return CLASS_DEFINITIONS[id]
 }

--- a/src/game/classes/data.ts
+++ b/src/game/classes/data.ts
@@ -1,0 +1,41 @@
+import type { CharacterClassDefinition, CharacterClassId } from "./types"
+
+export const CLASS_DEFINITIONS: Record<CharacterClassId, CharacterClassDefinition> = {
+  warrior: {
+    id: "warrior",
+    name: "Warrior",
+    description: "A battle-hardened fighter who relies on raw strength and heavy armor to overpower enemies.",
+    primaryAttribute: "strength",
+    baseStats: {
+      hp: 100,
+      barrier: 0,
+      attributes: { strength: 10, dexterity: 5, intelligence: 5 },
+    },
+  },
+  rogue: {
+    id: "rogue",
+    name: "Rogue",
+    description: "A swift and cunning combatant who exploits precision and agility to strike where it hurts most.",
+    primaryAttribute: "dexterity",
+    baseStats: {
+      hp: 60,
+      barrier: 0,
+      attributes: { strength: 5, dexterity: 10, intelligence: 5 },
+    },
+  },
+  mage: {
+    id: "mage",
+    name: "Mage",
+    description: "A wielder of arcane power who sacrifices physical resilience for devastating magical potential and a natural energy barrier.",
+    primaryAttribute: "intelligence",
+    baseStats: {
+      hp: 40,
+      barrier: 20,
+      attributes: { strength: 5, dexterity: 5, intelligence: 10 },
+    },
+  },
+} as const
+
+export function getClassDefinition(id: CharacterClassId): CharacterClassDefinition {
+  return CLASS_DEFINITIONS[id]
+}

--- a/src/game/classes/index.ts
+++ b/src/game/classes/index.ts
@@ -1,0 +1,2 @@
+export * from "./types"
+export { CLASS_DEFINITIONS, getClassDefinition } from "./data"

--- a/src/game/classes/types.ts
+++ b/src/game/classes/types.ts
@@ -1,17 +1,17 @@
 // ── Character attributes ──
 
 export interface CharacterAttributes {
-  strength: number
-  dexterity: number
-  intelligence: number
+	strength: number
+	dexterity: number
+	intelligence: number
 }
 
 // ── Base character stats (before gear) ──
 
 export interface CharacterBaseStats {
-  hp: number
-  barrier: number
-  attributes: CharacterAttributes
+	hp: number
+	barrier: number
+	attributes: CharacterAttributes
 }
 
 // ── Class definition ──
@@ -19,9 +19,9 @@ export interface CharacterBaseStats {
 export type CharacterClassId = "warrior" | "mage" | "rogue"
 
 export interface CharacterClassDefinition {
-  id: CharacterClassId
-  name: string
-  description: string
-  primaryAttribute: keyof CharacterAttributes
-  baseStats: CharacterBaseStats
+	id: CharacterClassId
+	name: string
+	description: string
+	primaryAttribute: keyof CharacterAttributes
+	baseStats: CharacterBaseStats
 }

--- a/src/game/classes/types.ts
+++ b/src/game/classes/types.ts
@@ -1,0 +1,27 @@
+// ── Character attributes ──
+
+export interface CharacterAttributes {
+  strength: number
+  dexterity: number
+  intelligence: number
+}
+
+// ── Base character stats (before gear) ──
+
+export interface CharacterBaseStats {
+  hp: number
+  barrier: number
+  attributes: CharacterAttributes
+}
+
+// ── Class definition ──
+
+export type CharacterClassId = "warrior" | "mage" | "rogue"
+
+export interface CharacterClassDefinition {
+  id: CharacterClassId
+  name: string
+  description: string
+  primaryAttribute: keyof CharacterAttributes
+  baseStats: CharacterBaseStats
+}


### PR DESCRIPTION
## Summary

- Add `src/game/classes/` module with type definitions (`CharacterClassId`, `CharacterClassDefinition`, `CharacterAttributes`, `CharacterBaseStats`)
- Define static data for Warrior (100 HP, STR primary), Mage (40 HP + 20 barrier, INT primary), and Rogue (60 HP, DEX primary)
- Include `getClassDefinition()` helper and barrel export via `index.ts`
- 15 tests covering all base stats, primary attributes, and lookup helper

## Test plan

- [x] All 15 class tests pass (`npx vitest run src/game/classes/classes.test.ts`)
- [x] Existing 128 item generator tests unaffected

Closes #12

🤖 Generated with [Claude Code](https://claude.com/claude-code)