### PR TITLE
docs: agent onboarding kit (codebase map + 6 playbooks + in-progress log)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,11 +1,21 @@
 # Shadows of Void — Project Guidelines
 
+## Orientation for a new agent
+
+Read these in order if you're new to the codebase:
+
+1. **[CONTEXT.md](./CONTEXT.md)** — domain glossary. What the game's rules ARE. Single source of truth.
+2. **[docs/codebase-map.md](./docs/codebase-map.md)** — where each domain lives in the repo. Use this instead of grepping blindly.
+3. **[docs/playbooks/](./docs/playbooks/)** — task recipes (add modifier, add monster, touch combat, etc). If your task matches one, follow it.
+4. **[docs/plans/in-progress.md](./docs/plans/in-progress.md)** — decisions made but not yet executed. Check before starting work to avoid colliding with a planned refactor.
+5. **[docs/adr/](./docs/adr/)** — architecture decisions (optimistic mutations, etc).
+
 ## Tech Stack
 
 - **Frontend:** React + TypeScript + Tailwind CSS + TanStack Router
 - **Backend:** Convex (database + auth)
 - **Build:** Vite + Biome (lint/format) + Vitest (testing)
-- **Path alias:** `#/*` → `./src/*`
+- **Path alias:** `#/*` → `./src/*` (client only — convex uses relative paths)
 
 ## Game Context
 

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -1,0 +1,203 @@
+# Codebase Map
+
+A fast tour for an agent dropped into this repo. Points to where each domain lives so you can grep with intent instead of with hope.
+
+For game design rules (what stats mean, what's allowed where, why), read [CONTEXT.md](../CONTEXT.md). For project guidelines (tech stack, item generator architecture), read [CLAUDE.md](../CLAUDE.md). For task recipes ("how do I add a modifier?"), read [docs/playbooks/](./playbooks/).
+
+---
+
+## Top-level layout
+
+```
+/
+├── CLAUDE.md               # Project guidelines + item-system architecture
+├── CONTEXT.md              # Domain glossary (single source of truth for rules)
+├── docs/
+│   ├── codebase-map.md     # ← you are here
+│   ├── playbooks/          # Task recipes (add modifier, add monster, etc)
+│   ├── plans/              # Roadmap + in-progress work
+│   └── adr/                # Architecture decisions
+├── convex/                 # Server (mutations, queries, schema)
+├── messages/               # Paraglide i18n source (pt.json, en.json)
+├── project.inlang/         # Paraglide config
+├── src/
+│   ├── game/               # Pure game data + rules (no React, no Convex)
+│   ├── components/         # React components
+│   ├── routes/             # TanStack file-based routes
+│   ├── hooks/              # React hooks
+│   ├── lib/                # Small utilities
+│   ├── paraglide/          # Generated i18n bindings (don't hand-edit)
+│   └── styles.css          # Global CSS + keyframes
+└── biome.json, vite.config.ts, package.json
+```
+
+---
+
+## `src/game/` — pure domain layer
+
+No React. No Convex. Same code runs on client and server (convex imports from here directly with relative paths). Pure functions, structured data, deterministic.
+
+| Directory | What lives there | Key files |
+|---|---|---|
+| `classes/` | Character class definitions (Warrior/Rogue/Mage) | `data.ts` (CLASS_DEFINITIONS), `types.ts` |
+| `combat/` | Damage/defense math, constants | `damage.ts`, `barrier.ts`, `leech.ts`, `constants.ts` |
+| `inventory/` | Inventory constants + helpers | `constants.ts` (INVENTORY_MAX_SLOTS, bySlotAsc) |
+| `items/` | Item generator, modifier data, equip helpers | See below — the biggest subdir |
+| `loot/` | Drop tables | `drops.ts` (rollDrop, rollMonsterLevel) |
+| `monsters/` | Monster definitions | `data.ts`, `types.ts` |
+| `progression/` | XP curves, HP scaling | `levels.ts` (xpToNextLevel, computeMaxHp, death penalty) |
+| `stats/` | The stat engine | `compute.ts` (computeCharacterStats), `types.ts` (EquippedSlot, narrowEquippedSlot, ComputedCharacterStats) |
+| `world/` | Acts, zones, node graph, zone-name i18n | `act-1.ts`, `index.ts`, `types.ts`, `i18n.ts` |
+
+### `src/game/items/` — item subsystem detail
+
+```
+items/
+├── generator.ts             # generateItem({ rarity, ilvl, type, weaponType }) — public API
+├── generator.test.ts        # 70+ tests covering rarity/tier/mod rules
+├── equipment.ts             # planEquip, validSlotsForItem, isTwoHanded, weaponArchetype — shared client+server
+├── equipment.test.ts        # planEquip rules (2H displacement, archetype, etc.)
+├── starter-gear.ts          # Hand-crafted starter weapons (rusty_sword, rusty_dagger, cracked_wand)
+├── mod-i18n.ts              # PT formatters for explicit mods + implicit pattern-match
+├── MODIFIER_GUIDELINES.md   # Notes on individual modifier semantics (crit, leech)
+├── data/
+│   ├── modifiers/           # One file per category — defines the modifier pool
+│   │   ├── index.ts         # Aggregates everything into MODIFIERS + ModifierId type
+│   │   ├── weapon-damage.ts # Local attack mods
+│   │   ├── spell-damage.ts  # Flat spell damage (staff/wand only)
+│   │   ├── global-damage.ts # Global %, attack/cast speed, global crit
+│   │   ├── defense.ts       # Local/global defense, life/mana, regen, thorns, block
+│   │   ├── resistances.ts
+│   │   ├── attributes.ts
+│   │   ├── utility.ts       # Movement speed, leech, stun, reduced reqs
+│   │   └── magic-find.ts
+│   └── templates/           # Equipment base templates, one file per slot/weapon type
+│       ├── swords.ts, daggers.ts, axes.ts, ...  (one per weapon type)
+│       ├── helmets.ts, chestplates.ts, boots.ts, gloves.ts
+│       ├── shields.ts
+│       └── rings.ts, amulets.ts, belts.ts
+└── types/
+    ├── base.ts              # EquipmentType, WeaponType, ArmorType, BaseStatKey, EQUIPMENT_GROUPS
+    ├── mods.ts              # Modifier, RolledMod, StatEffect, ModifierTier
+    ├── item.ts              # GeneratedItem (the thing stored in the items table)
+    └── index.ts
+```
+
+### `src/game/stats/compute.ts` — the stat engine
+
+The spine of every gameplay calculation. Read this if you're touching anything that reads character stats. Pure function, fixed-point cascade for broken-state detection, applies a single switch per modifier id.
+
+---
+
+## `convex/` — server (Convex backend)
+
+| File | Concern |
+|---|---|
+| `schema.ts` | Database tables: `characters`, `items`, `userRoles`. Indexes by `authUserId`, `characterId+locationKind`, `zoneSession`, `stash` |
+| `characters.ts` | **Kitchen sink — pending split.** Currently houses character CRUD, equip/unequip, zoneBag mutations, recordKill, syncHp, respawnDead. See [`docs/plans/in-progress.md`](./plans/in-progress.md) for the split plan |
+| `itemValidator.ts` | Convex validator for the `GeneratedItem` shape in `items.data` |
+| `auth.ts`, `auth.config.ts`, `users.ts` | better-auth integration + user role queries |
+| `http.ts` | Auth callback routes |
+
+Convex imports from `src/game/*` use **relative paths** (`../src/game/...`), not the `#/` alias — that's a Convex bundler quirk. Don't mix.
+
+---
+
+## `src/components/` — UI
+
+| File / dir | Role |
+|---|---|
+| `Modal.tsx` | Generic modal shell (dismissible flag, ESC handling) |
+| `Toaster.tsx` | Sonner wrapper — styled with Jersey 25 + uppercase tracking |
+| `Footer.tsx`, `Header.tsx` | Page chrome (only on splash) |
+| `CreateCharacterModal.tsx` | Used by character-select |
+| `ConfirmationModal.tsx` | Generic confirm dialog (used via `useConfirmationModal`) |
+| `game/ItemCard.tsx` | Shared item visual — rarity glow, broken state badge, tooltip portal |
+| `game/ItemTooltip.tsx` | The big tooltip — name, header stats, defenses, implicits, explicits |
+| `world/` | Everything inside the `/world` route |
+| `ui/` | Radix-ui-based primitives (Button, Input, Label, Select, etc) |
+
+### `src/components/world/` — world view internals
+
+| File | Role |
+|---|---|
+| `MapScene.tsx` | Act DAG rendering, hoverable nodes |
+| `CombatScene.tsx` | Enemy display, HP bars, **floating damage popups** (framer-motion) |
+| `CityScene.tsx` | City hub placeholder |
+| `EquipmentPanel.tsx` | Right-side paper doll (always-visible) |
+| `StatusCard.tsx` | Right-side stat readout + Show button + potion + HP globe |
+| `HealthGlobe.tsx` | Animated HP/barrier orb |
+| `TextLog.tsx` | Status line (priority chain: death → +XP → low HP → zone name) |
+| `InventoryModal.tsx` | The big one — drag-drop equip, click dropdown, 60-slot grid |
+| `ItemContextMenu.tsx` | Popover menu for click-to-equip |
+| `BagPreviewModal.tsx` | Read-only loot bag during combat |
+| `ExitZoneModal.tsx` | Post-retreat loot picker (5 buttons, selection grid) |
+| `ShowStatsModal.tsx` | Full character sheet (4 sections, PoE-style) |
+| `SettingsModal.tsx` | Language dropdown |
+| `InventoryButton.tsx` | Backpack icon button on EquipmentPanel |
+
+---
+
+## `src/routes/` — TanStack file-based routes
+
+| Route | Concern |
+|---|---|
+| `__root.tsx` | Layout shell + Toaster + ConfirmationProvider |
+| `index.tsx` | Splash screen ("Shadows of Void" title) |
+| `sign-in.tsx` | better-auth UI |
+| `character-select.tsx` | Roster + create modal + play button + delete confirm |
+| `world.tsx` | **Orchestrator** — combat hook, all modals, optimistic mutations, priority TextLog. Mid-size file (~470 lines) |
+| `admin.tsx`, `admin/items.tsx` | Admin dashboard (only admins see) |
+| `api/auth/$.ts` | better-auth fallback route |
+
+---
+
+## `src/hooks/` — React hooks
+
+| Hook | Purpose |
+|---|---|
+| `useCombatLoop.ts` | Tick orchestrator (50ms intervals, refs for sync state, search/engaged/victory state machine) |
+| `useCachedQuery.ts` | localStorage-backed wrapper around `useQuery` (cache version-tagged) |
+| `useConfirmationModal.tsx` | Promise-returning confirm() — works because of the ConfirmationProvider in `__root.tsx` |
+| `useModal.ts` | Open/close state for a single modal |
+| `useDamageEvents.ts` | Floating damage queue (timed cleanup, used by CombatScene) |
+| `useDelay.ts` | One-shot setTimeout wrapped |
+| `useTicker.ts` | Repeating setInterval wrapped |
+
+---
+
+## `src/lib/` — small utilities
+
+| File | Purpose |
+|---|---|
+| `convex-errors.ts` | `convexErrorMessage(err, fallback)` — translates known server errors to PT via `translateServerError` |
+| `rng.ts` | `randInt`, `pickRandom`, `pickWeighted` — used by generator + monster rolls |
+| `utils.ts` | `cn()` for classname merging |
+| `flash-toast.ts` | One-shot toast helper |
+| `auth-client.ts`, `auth-server.ts` | better-auth integration |
+
+---
+
+## `messages/` and `src/paraglide/`
+
+- **`messages/pt.json`** + **`messages/en.json`** are the source — edit these, paraglide regenerates `src/paraglide/messages.js` on the next dev run.
+- Import with `import { m } from "#/paraglide/messages"`. Call as `m.key_name({ param })`.
+- Strategy: localStorage → preferredLanguage → baseLocale (pt). No URL prefix.
+- `src/paraglide/` is generated — don't hand-edit, don't commit changes biome makes to it.
+
+---
+
+## Where to look when you ask…
+
+| Question | Start here |
+|---|---|
+| "How does crit work?" | `CONTEXT.md` → Combat Resolution → Damage formula. Code: `src/game/combat/damage.ts:rollPlayerSwing` |
+| "How do I add a new modifier?" | `docs/playbooks/adding-a-modifier.md` |
+| "Why does the inventory feel snappy?" | `docs/adr/0001-optimistic-mutations.md` |
+| "Where are the rules for what rolls on a belt?" | `CONTEXT.md` → Equipment Slots → Belt |
+| "What's an EquippedSlot?" | `src/game/stats/types.ts:EQUIPPED_SLOTS` + `narrowEquippedSlot` |
+| "Why is `convex/characters.ts` so big?" | `docs/plans/in-progress.md` — split is queued |
+| "What does the stat engine actually do?" | `src/game/stats/compute.ts` + tests in `compute.test.ts` |
+| "How does dual-wield work?" | `CONTEXT.md` → Dual-wielding |
+| "Why doesn't this Convex error look like English?" | `src/lib/convex-errors.ts:translateServerError` |
+| "How are items shown in the tooltip translated?" | `src/game/items/mod-i18n.ts` |

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -183,7 +183,7 @@ Convex imports from `src/game/*` use **relative paths** (`../src/game/...`), not
 - **`messages/pt.json`** + **`messages/en.json`** are the source — edit these, paraglide regenerates `src/paraglide/messages.js` on the next dev run.
 - Import with `import { m } from "#/paraglide/messages"`. Call as `m.key_name({ param })`.
 - Strategy: localStorage → preferredLanguage → baseLocale (pt). No URL prefix.
-- `src/paraglide/` is generated — don't hand-edit, don't commit changes biome makes to it.
+- `src/paraglide/` is generated — don't hand-edit. `biome.json` excludes the directory from lint/format so it never appears in diffs.
 
 ---
 

--- a/docs/plans/in-progress.md
+++ b/docs/plans/in-progress.md
@@ -1,0 +1,85 @@
+# In-progress work
+
+Decisions made but not yet executed. Read this before starting a session — if your task overlaps with something here, you may be duplicating planned work or causing conflicts.
+
+When a planned item starts, move it to a feature branch and reference back here. When it ships, delete the entry (closed work belongs in commit history, not this file).
+
+---
+
+## Split `convex/characters.ts` into domain modules
+
+**Status**: Planned, not started.
+**Branch**: not yet created. Will be `refactor/split-characters-mutations` from master.
+**Owner**: next agent picking this up.
+
+### Why
+
+`convex/characters.ts` is ~770 lines today, holding three unrelated domains:
+
+1. Character CRUD + base state (list, byId, create, remove, normalize helpers)
+2. Item lifecycle (equip, unequip, reorder, pickFromBag, discardFromBag, exitZone, zone bag queries, equipped/inventory queries)
+3. Combat / progression (recordKill, syncHp, usePotion, respawnDead, enterZone, enterCity)
+
+As skills, stash, vendor, and trade land, the file will hit 1500+ lines with overlapping concerns. The shared helpers (`loadOwnedCharacter`, `fetchInventoryAllocator`, `deleteZoneBag`, `narrowEquippedSlot`) make a split easy.
+
+### Planned split
+
+| New file | Houses |
+|---|---|
+| `convex/characters.ts` (kept) | `list`, `byId`, `create`, `remove`, `normalize` (private helper) — pure CRUD + roster |
+| `convex/items.ts` | `equipItem`, `unequipItem`, `reorderInventory`, `pickFromBag`, `discardFromBag`, `exitZone`, plus the queries `zoneBag`, `inventory`, `equipped`. Items table is the natural home for the bag mutations even though they touch `currentZoneSession` as a side effect |
+| `convex/combat.ts` | `enterZone`, `enterCity`, `recordKill`, `syncHp`, `usePotion`, `respawnDead`. The "what's happening in combat / what zone am I in" mutations |
+| `convex/_shared/character.ts` (new) | `loadOwnedCharacter`, `fetchInventoryAllocator`, `deleteZoneBag`, `newZoneSession`, `EQUIPPED_SLOT_LITERALS`/`equippedSlotValidator`. Private helpers re-exported here so all three modules import without circular references |
+
+### Client impact
+
+Every `api.characters.X` call site updates. There are ~30 across:
+
+- `src/routes/world.tsx` (most concentrated)
+- `src/components/world/InventoryModal.tsx`
+- `src/components/CreateCharacterModal.tsx`
+- `src/routes/character-select.tsx`
+
+Pattern: `api.characters.equipItem` → `api.items.equipItem`, `api.characters.recordKill` → `api.combat.recordKill`, etc. Mechanical change — TS errors will surface every site.
+
+### What NOT to touch in this refactor
+
+- **Mutation logic** — no behavior changes. Pure code move + import rewrites.
+- **Schema** — `convex/schema.ts` stays untouched. The split is presentation only.
+- **Tests** — no test file imports convex modules directly (they import from `src/game/items/equipment.ts` etc, which is shared). Should be no test changes.
+- **i18n keys** — error strings thrown by mutations stay verbatim so `translateServerError` keeps matching.
+
+### Validation
+
+```bash
+npx tsc --noEmit
+npx convex dev --once    # one-shot deploy check
+npx vitest run
+npx biome check src/ convex/
+```
+
+Then a smoke test: create character, kill a mob, retreat, equip something. If any of those fail, the issue is almost certainly a missed call site.
+
+---
+
+## Future: passive tree + active skills (not started)
+
+Per CONTEXT.md → Classes, the order is:
+
+1. MVP combat ✅ (done)
+2. Passive tree (not started — needs design)
+3. Active skills per class (not started — depends on passive tree)
+
+When a session starts working on this, expect to add a third combat path (alongside attack/spell) for skill casts, and a major refactor to the stat engine to handle skill-gem-style modifier sources.
+
+---
+
+## Future: stash + vendor (not started)
+
+Per CONTEXT.md → Stash and Vendor, the design is locked but no code exists:
+
+- Stash: account-scoped, mode-isolated (softcore / hardcore), 60 slots + purchasable tabs.
+- Vendor: per-act, sells consumables (potions today), buys gear for Rubys.
+- Ruby: currency. Monsters never drop Rubys directly.
+
+This is **scoped after** the passive tree because economy + progression need to balance against built characters.

--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -1,0 +1,33 @@
+# Playbooks
+
+Task recipes for common changes. Each playbook is a checklist of "touch these files in this order, run these commands at the end" so an agent doesn't have to rediscover the structure every time.
+
+Use these when the task matches an existing pattern. For one-off architectural changes, start from [`CONTEXT.md`](../../CONTEXT.md) and the [codebase map](../codebase-map.md) instead.
+
+## Playbooks
+
+- [Adding a modifier](./adding-a-modifier.md) — new mod to drop on items (most common)
+- [Adding an equipment template](./adding-an-equipment-template.md) — new weapon tier, new armor base
+- [Adding a monster](./adding-a-monster.md) — new mob template + zone hookup
+- [Adding a zone](./adding-a-zone.md) — new combat/city node in an act
+- [Adding a class](./adding-a-class.md) — new playable class
+- [Adding an i18n key](./adding-an-i18n-key.md) — new user-facing string
+- [Touching combat](./touching-combat.md) — read this before editing `useCombatLoop.ts`
+
+## Conventions
+
+Every playbook ends with the same validation sequence — you should always run these before considering a task done:
+
+```bash
+npx tsc --noEmit       # type-check
+npx vitest run         # all tests
+npx biome check src/   # lint + format
+```
+
+If your change touched convex code, also verify the dev server doesn't reject the schema:
+
+```bash
+npx convex dev --once  # one-shot deploy check
+```
+
+Don't bypass these. If a check fails, fix it before adding more changes.

--- a/docs/playbooks/adding-a-class.md
+++ b/docs/playbooks/adding-a-class.md
@@ -41,7 +41,13 @@ const blessedHammer: GeneratedItem = {
     baseStats: { minDamage: 2, maxDamage: 6, attackSpeed: 1.1, criticalChance: 5 },
     implicits: [],
     explicits: [],
-    computedStats: { ... },  // mirror baseStats for the computedStats shape
+    // computedStats mirrors baseStats since starters have no rolled mods.
+    computedStats: {
+        physicalDamage: { min: 2, max: 6 },
+        elementalDamage: [],
+        attackSpeed: 1.1,
+        criticalChance: 5,
+    },
 };
 ```
 

--- a/docs/playbooks/adding-a-class.md
+++ b/docs/playbooks/adding-a-class.md
@@ -1,0 +1,102 @@
+# Adding a class
+
+A class is a playable character archetype with starting attributes, starter equipment, and i18n'd name + description. Classes are otherwise mechanically identical today (passive tree + active skills are out of scope until those systems land).
+
+## Step 1 — Define the class
+
+Open `src/game/classes/data.ts`. Add an entry to `CLASS_DEFINITIONS`:
+
+```ts
+templar: {
+    id: "templar",
+    name: "Templar",
+    description: "Sacred warrior who channels divine power into martial discipline.",
+    primaryAttribute: "strength",
+    baseStats: {
+        hp: 80,
+        barrier: 10,
+        attributes: { strength: 8, dexterity: 4, intelligence: 8 },
+    },
+},
+```
+
+`CharacterClassId` in `types.ts` derives from `keyof typeof CLASS_DEFINITIONS`, so TS will surface compile errors at every consumer (starter-gear map, class-name i18n map, etc) that doesn't handle the new class.
+
+## Step 2 — Hook up the starter weapon
+
+Open `src/game/items/starter-gear.ts`:
+
+1. Define the starter weapon item (follow the existing `rustySword` / `rustyDagger` / `crackedWand` shape — pre-rolled, no requirements, namespaced `starter:` id):
+
+```ts
+const blessedHammer: GeneratedItem = {
+    id: "starter:blessed_hammer",
+    templateId: "blessed_hammer",
+    templateName: "Blessed Hammer",
+    equipmentType: "weapon",
+    weaponType: "mace",
+    rarity: "normal",
+    name: "Blessed Hammer",
+    itemLevel: 1,
+    baseStats: { minDamage: 2, maxDamage: 6, attackSpeed: 1.1, criticalChance: 5 },
+    implicits: [],
+    explicits: [],
+    computedStats: { ... },  // mirror baseStats for the computedStats shape
+};
+```
+
+2. Register it in `STARTER_ITEMS` and `STARTER_WEAPON_BY_CLASS`:
+
+```ts
+const STARTER_ITEMS = {
+    ...
+    "starter:blessed_hammer": blessedHammer,
+};
+
+export const STARTER_WEAPON_BY_CLASS = {
+    warrior: "starter:rusty_sword",
+    rogue: "starter:rusty_dagger",
+    mage: "starter:cracked_wand",
+    templar: "starter:blessed_hammer",
+};
+```
+
+The character creation mutation (`convex/characters.ts:create`) reads `STARTER_WEAPON_BY_CLASS[classId]` and inserts it as the equipped weapon. No convex changes needed.
+
+## Step 3 — Localize the class name + description
+
+`messages/pt.json` + `messages/en.json`:
+
+```json
+"class_templar_name": "Templário",
+"class_templar_description": "Guerreiro sagrado que canaliza poder divino em disciplina marcial."
+```
+
+(EN file gets the English versions.)
+
+## Step 4 — Wire the i18n maps
+
+Three places consume the class i18n today:
+
+1. **`src/components/CreateCharacterModal.tsx`** — `CLASS_NAME`, `CLASS_DESCRIPTION`, and `CLASS_LIST` const arrays. Add `templar` to `CLASS_LIST` and to both maps.
+2. **`src/components/world/StatusCard.tsx`** — `CLASS_NAME` map. Add the templar entry.
+3. **`src/routes/character-select.tsx`** — `CLASS_NAME` map at the top of the file. Add templar.
+
+TS will flag any of these you miss — `Record<CharacterClassId, () => string>` requires every key be present.
+
+## Step 5 — Verify
+
+```bash
+npx tsc --noEmit
+npx vitest run
+npx biome check src/
+```
+
+Then `npm run dev`, open the character-select modal, scroll the class list, verify:
+- Name renders in PT and EN (toggle locale via settings modal).
+- Description renders correctly.
+- After creating, the starter weapon shows in the paper doll and the items table query returns it as equipped.
+
+## Future: per-class identity
+
+The class system today is **starting attributes + starter weapon** only. When passive trees and active skills land, each class gets a passive tree branch and 1-3 starter skills — that work hasn't started yet and is tracked in [`docs/plans/in-progress.md`](../plans/in-progress.md).

--- a/docs/playbooks/adding-a-modifier.md
+++ b/docs/playbooks/adding-a-modifier.md
@@ -25,23 +25,28 @@ Open the right file under `src/game/items/data/modifiers/`:
 - Movement speed, leech, stun, on-kill, reduced reqs → `utility.ts`
 - Item Rarity (Magic Find) → `magic-find.ts`
 
-Add an entry:
+Add an entry. The example below is a complete, copy-pasteable `increased`
+prefix; swap `Increase` for `Flat` (and `modifierType: "flat"`) for an
+additive mod, or `Suffix Name` + `affixType: "suffix"` for a suffix.
 
 ```ts
-myNewMod: {
-    id: "myNewMod",
-    name: "Prefix Name" | "of Suffix Name",
-    affixType: "prefix" | "suffix",
-    modifierType: "flat" | "increased",
-    category: "offensive" | "defensive" | "attribute" | "utility",
-    applicableTo: ["allArmor", "ring"],  // groups + specifics, see EQUIPMENT_GROUPS
-    displayFormat: "+{value} Some Stat",
-    isGlobalStat: true,           // omit for local mods
-    statEffect: { ... },          // REQUIRED for local mods — see CLAUDE.md
-    weight: 800,                  // omit for default (1000)
-    tiers: createStandardTiers(t10Min, t10Max, t1Min, t1Max),
+myNewStatIncrease: {
+    id: "myNewStatIncrease",           // id must end in Flat / Increase / More
+    name: "Prefix Name",                // shown in the magic-item generated name
+    affixType: "prefix",                // or "suffix" — flips name to "of Suffix Name"
+    modifierType: "increased",          // or "flat" — must match the id's suffix
+    category: "offensive",              // offensive | defensive | attribute | utility
+    applicableTo: ["allArmor", "ring"], // groups + specific slots, see EQUIPMENT_GROUPS
+    displayFormat: "+{value}% Some Stat",
+    isGlobalStat: true,                 // omit for local mods (statEffect required instead)
+    weight: 800,                        // omit for default (1000)
+    tiers: createStandardTiers(5, 10, 30, 45), // (t10Min, t10Max, t1Min, t1Max)
 },
 ```
+
+Local mods (the ones that mutate a weapon's `computedStats`) need a
+`statEffect` declaration instead of `isGlobalStat: true`. See CLAUDE.md
+"statEffect" for the target/operation table.
 
 The modifier id ends in `Flat` / `Increase` / `More` — the suffix and `modifierType` must agree. See `CONTEXT.md` → Modifier ID Naming Convention.
 

--- a/docs/playbooks/adding-a-modifier.md
+++ b/docs/playbooks/adding-a-modifier.md
@@ -1,0 +1,95 @@
+# Adding a modifier
+
+A "modifier" is a rolled affix on a generated item — e.g. "+15 Strength", "+20% Increased Fire Damage". Adding one touches 3-4 files in predictable spots.
+
+## Decide first
+
+Before writing code:
+
+1. **Is it local or global?** Local mods affect the item's own computed stats (a weapon's `+X% Physical Damage` only buffs that weapon). Global mods sum into character totals and apply universally. See `CLAUDE.md` "Local vs Global" if you're unsure.
+2. **Which category?** offensive / defensive / attribute / utility. Picks the file the new mod lives in.
+3. **Which slots accept it?** Use the equipment groups (`allArmor`, `allJewelry`, `allAttackWeapons`) where possible — see `src/game/items/types/base.ts`. Mixing groups with specific slots is fine.
+4. **What's its weight?** Default 1000. Higher = more common. Premium mods get 400-600, fillers get 1500-2000. See `CONTEXT.md` "Modifier Knobs" → Reference weights.
+5. **What's its tier range?** 10 tiers gated by ilvl. `createStandardTiers(t10Min, t10Max, t1Min, t1Max)` interpolates linearly. Pick min/max values for the weakest tier and strongest tier.
+
+## Step 1 — Define the modifier
+
+Open the right file under `src/game/items/data/modifiers/`:
+
+- Attack damage / crit / attack speed → `weapon-damage.ts`
+- Flat spell damage (staff/wand only) → `spell-damage.ts`
+- Global damage %, global crit, global cast/attack speed → `global-damage.ts`
+- Armor / evasion / barrier / life / mana / block / thorns → `defense.ts`
+- Resistances → `resistances.ts`
+- Str/Dex/Int → `attributes.ts`
+- Movement speed, leech, stun, on-kill, reduced reqs → `utility.ts`
+- Item Rarity (Magic Find) → `magic-find.ts`
+
+Add an entry:
+
+```ts
+myNewMod: {
+    id: "myNewMod",
+    name: "Prefix Name" | "of Suffix Name",
+    affixType: "prefix" | "suffix",
+    modifierType: "flat" | "increased",
+    category: "offensive" | "defensive" | "attribute" | "utility",
+    applicableTo: ["allArmor", "ring"],  // groups + specifics, see EQUIPMENT_GROUPS
+    displayFormat: "+{value} Some Stat",
+    isGlobalStat: true,           // omit for local mods
+    statEffect: { ... },          // REQUIRED for local mods — see CLAUDE.md
+    weight: 800,                  // omit for default (1000)
+    tiers: createStandardTiers(t10Min, t10Max, t1Min, t1Max),
+},
+```
+
+The modifier id ends in `Flat` / `Increase` / `More` — the suffix and `modifierType` must agree. See `CONTEXT.md` → Modifier ID Naming Convention.
+
+**The generator will pick it up automatically** via the `MODIFIERS` spread in `src/game/items/data/modifiers/index.ts`. No registration needed.
+
+## Step 2 — Teach the stat engine to consume it (global mods only)
+
+If it's a global mod (`isGlobalStat: true`), add a case in the `applyMod()` switch in `src/game/stats/compute.ts`:
+
+```ts
+case "myNewMod":
+    stats.someField += v;
+    return;
+```
+
+If the field doesn't exist yet on `ComputedCharacterStats`, add it in `src/game/stats/types.ts` and default it in `blankStats()` in `compute.ts`.
+
+If the mod affects damage calculations, also wire it through `rollPlayerSwing` in `src/game/combat/damage.ts` — the increased pools live in `stats.increased`.
+
+**Local mods skip this step** — `statEffect` already tells the generator how to bake the value into the weapon's `computedStats`. Verify it's reflected in `src/game/items/generator.ts:computeWeaponStats` if you added a new `LocalStatTarget`.
+
+## Step 3 — Add Portuguese localization
+
+Open `src/game/items/mod-i18n.ts` and add an entry to `PT_EXPLICIT_FORMATTERS`:
+
+```ts
+myNewMod: (v) => `+${v} de Coisa`,
+```
+
+The format must match the meaning of `displayFormat` from step 1. If your mod can appear as an **implicit** on a template, add a regex pattern to `PT_IMPLICIT_PATTERNS` too.
+
+## Step 4 — Verify
+
+```bash
+npx tsc --noEmit
+npx vitest run src/game/items/generator.test.ts
+npx vitest run src/game/stats/compute.test.ts
+```
+
+Generator tests will catch:
+- "no decimals in rolled values"
+- "prefix/suffix limits per rarity"
+- "Magic items don't exceed 2 mods"
+
+Stat engine tests will catch missing `applyMod` case (the universal `globalDamageIncrease` was once removed for exactly this reason — see commit history).
+
+If the mod is balance-sensitive (premium weight, exclusive slot), drop in a `weight: N` comment explaining the rationale — future agents won't know.
+
+## Step 5 — Test the drop visually
+
+Run `npm run dev`, create or load a character, retreat from a zone with items in the bag, open the loot picker. Verify the new mod shows on dropped items with the right localized text.

--- a/docs/playbooks/adding-a-monster.md
+++ b/docs/playbooks/adding-a-monster.md
@@ -1,0 +1,63 @@
+# Adding a monster
+
+A monster is a mob template with base stats, an emoji, an XP reward, and the rarities it can spawn at.
+
+## Step 1 — Define the monster
+
+Open `src/game/monsters/data.ts`. Add an entry to `MONSTERS`:
+
+```ts
+my_new_mob: {
+    id: "my_new_mob",
+    name: "Stone Goblin",
+    emoji: "🗿",
+    baseStats: {
+        hp: 18,
+        attackSpeed: 0.9,
+        minDamage: 3,
+        maxDamage: 6,
+    },
+    xpReward: 12,
+    allowedRarities: ["normal", "magic"],   // rare is reserved for minibosses
+},
+```
+
+The `MonsterId` type derives from the keys of `MONSTERS` (`keyof typeof MONSTERS`), so the id strings get type-checked everywhere automatically — you'll see compile errors at zone declarations that reference the new id once it's added.
+
+## Step 2 — Add to a zone's monster pool
+
+Open `src/game/world/act-1.ts` (or whichever act you're populating). Find the zone where the monster should spawn and add the id to `monsterPool`:
+
+```ts
+{
+    id: "starter_forest",
+    name: "Floresta Inicial",
+    kind: "combat",
+    monsterPool: ["goblin", "my_new_mob"],
+    level: 2,
+    ...
+}
+```
+
+## Step 3 — Localize the name (if it's user-facing in any new context)
+
+`MONSTERS[id].name` is currently the canonical English fallback. The name field is shown directly in the enemy nameplate during combat (see `CombatScene.tsx`).
+
+If you want a different name in Portuguese, check `messages/pt.json` and `messages/en.json` for a `monster_*` key pattern. Add a new key (e.g. `monster_stone_goblin`) and route it via the appropriate i18n switch in the UI. Today only `monster_goblin` is i18n'd — you can either follow that pattern or update the schema to look up monster names by key.
+
+For an MVP test mob, leaving the name as the data-file `name` is fine — it just won't translate.
+
+## Step 4 — Verify
+
+```bash
+npx tsc --noEmit
+npx vitest run
+```
+
+Then enter the zone in `npm run dev` and confirm the new monster shows up. Note the mob roll is uniformly random across `monsterPool` — to verify rare monsters in a pool, you may need to retry a few times.
+
+## Gotcha: damage balance
+
+Monster damage is raw. There's no formula scaling it against zone level or player armor today (player armor mitigates via `applyArmor` in `damage.ts`, but the input is just `randInt(minDamage, maxDamage)`). Pick values relative to neighboring mobs in the same zone, not against player HP.
+
+A zone-level-2 mob shouldn't deal more than ~10 damage on average to a starter character (max HP ~100, no defenses).

--- a/docs/playbooks/adding-a-zone.md
+++ b/docs/playbooks/adding-a-zone.md
@@ -1,0 +1,64 @@
+# Adding a zone
+
+A zone is a node in an act's DAG. It's either a combat zone (mobs spawn, boss threshold) or a city (safe hub). This playbook covers combat zones; cities follow the same shape with `kind: "city"` and no monster pool.
+
+## Step 1 — Add the node
+
+Open `src/game/world/act-1.ts` (or your target act). Add an entry to the `nodes` array:
+
+```ts
+{
+    id: "shadow_glade",
+    name: "Shadow Glade",                  // canonical English name
+    kind: "combat",
+    position: { x: 0.45, y: 0.6 },         // 0..1 on the map render
+    connections: ["starter_forest", "ruined_outpost"],
+    monsterPool: ["goblin", "shade"],      // see adding-a-monster
+    level: 4,                              // zone level — drives ilvl + mob instance level
+},
+```
+
+Connections are undirected — listing the edge on one side is enough but listing on both makes the data easier to read.
+
+## Step 2 — Add the localized name
+
+Two files:
+
+**`messages/pt.json`** — add a new key:
+
+```json
+"zone_shadow_glade": "Clareira Sombria",
+```
+
+**`messages/en.json`** — matching key:
+
+```json
+"zone_shadow_glade": "Shadow Glade",
+```
+
+Then wire it up in `src/game/world/i18n.ts:translateNodeName`:
+
+```ts
+case "shadow_glade":
+    return m.zone_shadow_glade();
+```
+
+The fallback in that switch returns the node's `name` field as-is. Without the i18n entry, the zone shows in English regardless of locale.
+
+## Step 3 — Verify ilvl + monsterPool
+
+- The zone's `level` controls `rollMonsterLevel` (mob instance level = zoneLevel ± 1) and drop ilvl (matches monster instance level). See `CONTEXT.md` → Zone level and monster instance level.
+- Drops are gated by mob instance level — levels 1-4 don't drop jewelry (see `CONTEXT.md` → Drop pool). Verify your zone's level falls in the right band.
+
+## Step 4 — Verify
+
+```bash
+npx tsc --noEmit
+npx vitest run
+```
+
+Then load the world view in `npm run dev`, hover the node on the map to confirm the name renders correctly, click to enter, kill a mob, retreat, and check the loot bag for items at the expected ilvl band.
+
+## Future: boss zones
+
+`kind: "boss"` is reserved for act-boss nodes (Act 1's final node uses model B — see `CONTEXT.md` → Act Boss). Not yet implemented — refer to the act-boss section before adding a boss node.

--- a/docs/playbooks/adding-an-equipment-template.md
+++ b/docs/playbooks/adding-an-equipment-template.md
@@ -1,0 +1,104 @@
+# Adding an equipment template
+
+A "template" is a base item — a tier of sword, a base of helmet. Templates carry baseline stats (damage range, attack speed for weapons; defense value for armor), level + attribute requirements, and any implicits (free stats that always roll on this base).
+
+## Decide first
+
+1. **What slot?** Weapon (which type — sword/dagger/staff/etc), helmet, chestplate, boots, gloves, ring, amulet, belt, offhand (shield).
+2. **What tier slot in the ladder?** Templates ladder by ilvl gating. Pick the next sequential id (`rusty_sword`, `iron_sword`, `steel_sword`, ...).
+3. **For armor: what base type?** plate / leather / silk — determines whether `localDefenseFlat` resolves to armor / evasion / barrier (see `CONTEXT.md` → Armor Bases).
+4. **Requirements?** Level + str/dex/int. Look at neighboring templates for the same type to keep the curve consistent.
+5. **Implicits?** Most don't have any. Jewelry (rings, amulets) often does — usually a resistance or attribute roll. See `src/game/items/data/templates/rings.ts` for examples.
+
+## Step 1 — Add the template
+
+Open the right file under `src/game/items/data/templates/`. One file per category:
+
+| Slot | File |
+|---|---|
+| sword | `swords.ts` |
+| dagger | `daggers.ts` |
+| axe | `axes.ts` |
+| mace | `maces.ts` |
+| greatsword | `greatswords.ts` |
+| twoHandedAxe | `two-handed-axes.ts` |
+| bow | `bows.ts` |
+| staff | `staves.ts` |
+| wand | `wands.ts` |
+| helmet | `helmets.ts` |
+| chestplate | `chestplates.ts` |
+| boots | `boots.ts` |
+| gloves | `gloves.ts` |
+| shield | `shields.ts` |
+| ring | `rings.ts` |
+| amulet | `amulets.ts` |
+| belt | `belts.ts` |
+
+Add an entry to the exported array:
+
+```ts
+{
+    id: "iron_sword",                  // unique across all templates
+    name: "Iron Sword",
+    equipmentType: "weapon",
+    weaponType: "sword",               // weapons only
+    armorType: "plate",                // armor only
+    minItemLevel: 8,                   // first ilvl this can drop at
+    maxItemLevel: 12,                  // last ilvl this can drop at
+    baseStats: {
+        minDamage: 5,
+        maxDamage: 10,
+        attackSpeed: 1.4,
+        criticalChance: 6,             // weapons only — armor uses { armor, evasion, barrier }
+    },
+    requirements: { level: 8, str: 16, dex: 16 },
+    implicits: [],                     // or [{ displayFormat: "+{value}% Cold Resistance", minValue: 15, maxValue: 25 }]
+},
+```
+
+The generator picks templates from `src/game/items/data/templates/index.ts` — the spread is automatic, no registration needed.
+
+## Step 2 — Verify ilvl bands
+
+Templates of the same type form a ladder. Check that `minItemLevel`/`maxItemLevel` bands don't overlap with siblings or leave gaps — the generator picks the matching template per drop ilvl, and an unmatched ilvl crashes the roll.
+
+Quick sanity check:
+
+```bash
+npx vitest run src/game/items/generator.test.ts
+```
+
+The generator tests roll thousands of items and would catch a gap.
+
+## Step 3 — Implicit i18n (if you added one)
+
+If your template has implicits with English `displayFormat` strings, check `src/game/items/mod-i18n.ts:PT_IMPLICIT_PATTERNS`. If your implicit pattern isn't already covered there, add a regex + render function:
+
+```ts
+{
+    test: /^\+\d+ Maximum Mana$/i,
+    render: (v) => `+${v} de Mana Máxima`,
+},
+```
+
+Implicits don't have modifier ids — the matcher works on the literal English string.
+
+## Step 4 — Verify
+
+```bash
+npx tsc --noEmit
+npx vitest run
+npx biome check src/
+```
+
+Open the admin items panel if you have admin role (`/admin/items`) and roll a few drops at your template's ilvl band to eyeball the result.
+
+## Gotcha: requirement curves
+
+Look at the existing curve before picking your numbers. For example:
+
+- Swords requirement curve: STR + DEX both, starting (10, 10) at level 1, scaling to (~112, 112) at level 80
+- Axes: STR only, (15) at level 1, (~140) at level 80
+- Wands: INT only, (10) at level 1, (~138) at level 80
+
+A new tier 5 sword should sit between tier 4 and tier 6 cleanly — about (25, 25) STR/DEX. Don't make up numbers; interpolate from siblings.

--- a/docs/playbooks/adding-an-i18n-key.md
+++ b/docs/playbooks/adding-an-i18n-key.md
@@ -1,0 +1,54 @@
+# Adding an i18n key
+
+Every user-facing string goes through paraglide. The source files are `messages/pt.json` and `messages/en.json`. Both are required — pt is the base locale and en is the alternate.
+
+## When you need a new string
+
+1. **Open both `messages/pt.json` and `messages/en.json`** and add the same key with values for each locale:
+
+```json
+"my_new_key": "Texto em Português",
+"my_new_key_with_param": "Você ganhou {amount} XP"
+```
+
+(EN file gets the English versions.)
+
+2. **Place it semantically.** The files are loosely grouped (character-select keys near other character-select keys, status_* near status_*, etc.). Add yours next to its neighbors so future agents can find it by scanning.
+
+3. **Use it via the `m` proxy:**
+
+```ts
+import { m } from "#/paraglide/messages";
+
+<p>{m.my_new_key()}</p>
+<p>{m.my_new_key_with_param({ amount: 12 })}</p>
+```
+
+Paraglide auto-regenerates `src/paraglide/messages.js` on the next dev run (or via `npx paraglide-js compile`). You don't normally need to run it manually — it picks up changes automatically.
+
+## Conventions
+
+- **snake_case** keys (`status_class_label`, not `statusClassLabel`).
+- **Prefix by area** when you have several related keys: `inventory_*`, `stats_*`, `error_*`, `equip_*`, `loot_*`.
+- **Plural variants** use `_one` / `_other` suffixes when count-dependent (see `inventory_free_slot_one`/`_other` for the pattern). The caller picks: `count === 1 ? m.x_one({ count }) : m.x_other({ count })`. Paraglide has built-in ICU plurals but we keep it explicit per call site.
+- **Strings with params** use `{name}` braces. Paraglide validates that all locales include the same placeholders — if pt has `{amount}` and en doesn't, the build errors.
+
+## Never hardcode user-facing text
+
+If you find yourself writing a string literal in a `<button>`, `<p>`, `toast.*()`, or `aria-label`, stop and add a key. The error pattern is easy to spot in code review — Portuguese accents (`ção`, `ões`) or English UI words in component files.
+
+The only exceptions:
+- Debug-only text (never shown to users)
+- Internal modifier ids, slot ids, etc — system identifiers, not display strings
+
+## Server-side errors
+
+Server errors thrown from convex mutations as `throw new ConvexError("Inventory overflow")` are in English by design (the server doesn't know the locale). The translation happens client-side via `src/lib/convex-errors.ts:translateServerError`, which pattern-matches known server strings and returns the right PT key.
+
+When you add a new server error:
+
+1. Throw with a stable, distinctive English string in the convex mutation.
+2. Add matching `error_*` paraglide keys in both locales.
+3. Add a pattern (exact match or regex) in `translateServerError` that returns the localized key.
+
+See the existing patterns in `src/lib/convex-errors.ts` for the structure.

--- a/docs/playbooks/touching-combat.md
+++ b/docs/playbooks/touching-combat.md
@@ -1,0 +1,97 @@
+# Touching combat
+
+Before you change `src/hooks/useCombatLoop.ts` or the pure combat math in `src/game/combat/`, read this. The combat loop has subtle constraints that will bite an agent that touches it casually.
+
+## The architecture
+
+Combat is a state machine driven by an interval ticker (50ms) in a single React hook.
+
+```
+            ┌──────────┐  spawn delay  ┌──────────┐ enemy.hp = 0  ┌─────────┐
+state:      │ searching│ ───────────── ▶│ engaged  │ ─────────────▶│ victory │
+            └──────────┘ (1500ms)      └──────────┘                └─────────┘
+                  ▲                          │                          │
+                  └──────────────────────────┴──────────────────────────┘
+                                victory delay (800ms)
+```
+
+Each tick at `engaged`:
+
+1. Update leech instances (delivers regen).
+2. Tick the barrier recovery timer (refills at expiry).
+3. Advance `playerProgress` by `dt × stats.tickRate`.
+4. Advance `enemyProgress` by `dt × enemyAttackSpeed`.
+5. If `playerProgress >= 1`, subtract 1 and fire a player swing.
+6. If `enemySwing`, fire an enemy attack (after the player's swing — player acts first).
+
+When the player swings:
+
+- Pick the active swing from `stats.swings` (dual-wield alternates via `nextSwingIndexRef`).
+- Call `rollPlayerSwing` (pure function in `src/game/combat/damage.ts`) — returns `{ amount, isCrit, isMiss, breakdown }`.
+- If the result is a hit: subtract from enemy HP, push a damage event, optionally spawn a leech instance, fire life-on-hit.
+- If the enemy is dead: transition to `victory`, fire `recordKill` mutation (server records XP + rolls drops), return.
+
+## The big traps
+
+### 1. React batching vs sync state
+
+You **cannot** rely on `useState` setters to be visible synchronously inside the same tick callback. We work around this with refs:
+
+- `stateRef.current` — read instead of `state`.
+- `enemyRef.current` — read + mutate; setEnemy is just for re-render.
+- `playerHpRef.current` — same pattern.
+- `deadRef.current` — guards against double-firing death.
+- `nextSwingIndexRef.current` — dual-wield alternation across ticks.
+
+**Rule:** if a value is read inside the tick callback AND set somewhere else in the same tick, use a ref. The `setX` call is for rendering. The ref is for logic.
+
+When you add a new piece of mid-tick state, follow the same pattern: declare both `const [foo, setFoo] = useState(...)` and `const fooRef = useRef(foo)`, and write to both (`fooRef.current = next; setFoo(next)`).
+
+### 2. The activation effect
+
+`useCombatLoop` takes an `active: boolean` prop. When it flips:
+
+- `active && !wasActive`: pull server HP, clear leech instances, reset swing index, switch to `searching`.
+- `!active && wasActive && !dead`: flush HP back to server via `syncHp`.
+
+If you change the combat hook to accept additional state that needs activation handling, add it to that `useEffect` block.
+
+### 3. The dead guard
+
+When the player dies:
+
+1. `deadRef.current = true` immediately (so subsequent ticks don't re-fire death).
+2. `queueMicrotask(() => onPlayerDeath())` — defers the callback so React renders the death message before the route navigates away.
+
+If you add anything that touches `playerHp` post-death, gate it on `!deadRef.current` or the respawn flow will race with the stale 0 HP.
+
+### 4. Combat is paused but the loot picker is open
+
+`active` is `view === "combat" && !exitModal.isOpen`. When the player retreats, view flips to map, but the modal stays open with the bag. Combat stops ticking but the player's HP stays at whatever it was — that's intentional, so they aren't damaged while picking loot.
+
+### 5. Tests use deterministic randoms
+
+Pure combat tests (`src/game/combat/*.test.ts`) pass `random: () => 0.5` to force hits + no crits. If you add a new path that branches on `random()`, write the test with an explicit random fn that produces the path you want to test.
+
+## What's safe to change
+
+- **Pure functions** in `src/game/combat/damage.ts`, `barrier.ts`, `leech.ts` — changing these is mechanically safe as long as the existing tests pass. They have no React or Convex dependency.
+- **The damage formula** — read `CONTEXT.md` → "Damage formula" first. The formula is documented; if you change it, update the doc.
+- **The state machine transitions** — guarded but careful. Adding a new state (e.g. `stunned`) means adding ref tracking and respecting the activation transition.
+
+## What's dangerous to change
+
+- **The tick interval (50ms)** — affects perceived smoothness. Lower = smoother but more re-renders; higher = janky.
+- **The ref+state pattern** — converting refs back to state will break kill detection (the goblin-not-dying bug was exactly this — see commit history for `enemyRef`).
+- **The order of player vs enemy swing in a tick** — player-first is a design decision (CONTEXT.md → Tick order). Reversing it gives the player a damage disadvantage equivalent to one swing.
+
+## When you finish
+
+```bash
+npx tsc --noEmit
+npx vitest run src/game/combat/
+npx vitest run src/game/stats/
+npx biome check src/hooks/ src/game/combat/
+```
+
+Then `npm run dev`, kill at least 5 mobs to verify victory transitions work, take damage to barrier to verify the 6s recovery, and use a potion mid-combat to verify the optimistic update doesn't conflict with HP sync.


### PR DESCRIPTION
## Summary

Closes the documentation gap that would slow down a context-reset agent or block multiple parallel agents from working without colliding.

- **docs/codebase-map.md** — module-by-module tour, with a "Where to look when you ask..." routing table at the bottom.
- **docs/playbooks/** (6 recipes) — predictable touch-list for the most common tasks: adding a modifier, equipment template, monster, zone, class, i18n key. Plus a "Touching combat" guide capturing the ref-vs-state pattern and three other traps I've seen break combat in commit history.
- **docs/plans/in-progress.md** — single decisions-made-but-not-done log. Currently lists the planned `convex/characters.ts` split (next planned refactor).
- **CLAUDE.md** gained an "Orientation for a new agent" section at the top pointing at these in reading order.

Pure docs; no code behavior changes. Paraglide bindings were regenerated to pick up `slot_label_*` keys from the previous PR (the compile step was missing on master).

## Test plan

- [ ] Open `docs/codebase-map.md` and verify every linked path resolves.
- [ ] Open `docs/playbooks/README.md` and click through to each playbook.
- [ ] Open `CLAUDE.md` and confirm the orientation section reads well as a first-stop.
- [ ] Spot-check `docs/playbooks/adding-a-modifier.md` against the actual code paths it describes.
- [ ] Confirm `docs/plans/in-progress.md` captures the convex split intent accurately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)