### PR TITLE
feat: dual-wielding mean rate + 10% AS/block implicits

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -169,7 +169,7 @@ Opened via the existing `InventoryButton` (backpack icon in `EquipmentPanel`). W
 Combat is automatic and **status-machine driven**: both sides have stats, attack rates, and mitigation, and damage is applied tick-by-tick by the formulas below. The player has no per-hit input in MVP combat; skills with cooldowns are a later layer that will plug into this same machine.
 
 ### Per-tick attack
-- Each side has an **attack rate** (attacks per second). Example: a 1.8 attack-speed weapon resolves 1.8 hits/sec. Dual-wielders use a combined alternating rate (see "Dual-wielding").
+- Each side has an **attack rate** (attacks per second). Example: a 1.8 attack-speed weapon resolves 1.8 hits/sec. Dual-wielders use the **average** of both weapons' base speeds, alternating which weapon swings each tick (see "Dual-wielding").
 - The defending side mitigates with its **armor / evasion / barrier / resistances** before the hit lands. Whatever remains is subtracted from life (and barrier, where applicable).
 - Life leech, regen, on-hit, on-kill effects fire per their own triggers as part of the same machine.
 
@@ -206,7 +206,7 @@ Each incoming hit rolls against `hitChance`. A miss deals **zero** damage and tr
 - When the timer expires, barrier refills to **100% instantly** (single-tick refill, not gradual).
 - Barrier does not regenerate while above zero — the refill mechanic is the only recovery.
 
-**Block** (shield-only) — when a hit lands and is not evaded, roll once against `blockChance`. A blocked hit deals 0 damage to barrier/life but **does** trigger the attacker's on-hit (blocks are still "hits" for the attacker's purposes). Thorns still reflect to the attacker on block.
+**Block** — granted by **shields** (base + rolled mods) and by **attack dual-wielding** (flat +10% implicit). When a hit lands and is not evaded, roll once against `blockChance`. A blocked hit deals 0 damage to barrier/life but **does** trigger the attacker's on-hit (blocks are still "hits" for the attacker's purposes). Thorns still reflect to the attacker on block, regardless of whether the block came from a shield or from dual-wielding.
 
 ### Leech
 Per hit that lands and deals damage:
@@ -560,12 +560,14 @@ A second one-handed weapon may go in the off-hand slot. When both hands hold a w
 **Same-archetype rule**: dual-wielding requires both weapons to share archetype. Attack 1H + attack 1H is allowed (sword + dagger, axe + sword, etc.). Caster 1H + caster 1H is allowed (wand + wand — the only caster combination). **Mixed archetype is rejected** (no sword + wand). This keeps the combat tick model coherent — one path (attack or spell) active at a time.
 
 **Combat behaviour**:
-- Combined tick rate = `mainHand.attackSpeed + offHand.attackSpeed` (or `castSpeed` for caster pairs).
+- Combined tick rate = `average(mainHand.attackSpeed, offHand.attackSpeed)` (or `castSpeed` for caster pairs). Attack dual-wielding multiplies that average by an additional **+10% (more multiplier)** as an implicit style buff; wand+wand uses the plain average with no buff.
 - Ticks **alternate**: tick 1 = main hand swings, tick 2 = off-hand, tick 3 = main hand again. The swinging weapon's local stats (base damage, local mods, weapon-specific crit chance) source that tick's damage.
 - Global modifiers (`+X% Increased Physical`, `+X Strength`, global crit chance/multi, resistances, attributes) apply on **every** swing, regardless of which weapon is active.
 - Cast speed base is `1.0` for caster weapons (no per-template base); cast speed mods scale that baseline.
 
-There is no implicit dual-wield damage or attack-speed bonus — the value of dual-wielding is the doubled tick rate. The trade-off vs shield is straightforward: shield offers block + thorns + defensive stats, dual-wielding offers raw rate.
+**Attack dual-wielding implicits** (attack-1H + attack-1H only): **+10% attack speed** (applied as a more multiplier on top of the averaged base) and **+10% block chance** (additive to `blockChance`, still bound by the 75% block cap). Wand+wand does not receive either buff.
+
+The trade-off vs shield: shield offers higher block ceilings, thorns rolls, and defensive stats from a dedicated slot; attack dual-wielding offers a second weapon's local mods (flat damage, local AS/crit) plus the modest +10% AS / +10% block implicits.
 
 ---
 

--- a/messages/en.json
+++ b/messages/en.json
@@ -213,6 +213,7 @@
   "stats_main_hand": "Main Hand",
   "stats_off_hand": "Off Hand",
   "stats_dual_wield_pattern": "Alternation: {pattern}",
+  "stats_dual_wield_bonus": "Dual-Wielding: +10% Attack Speed, +10% Block",
   "stats_increased_header": "Increased",
   "stats_increased_physical": "Physical",
   "stats_increased_cold": "Cold",

--- a/messages/pt.json
+++ b/messages/pt.json
@@ -213,6 +213,7 @@
   "stats_main_hand": "Mão Principal",
   "stats_off_hand": "Mão Secundária",
   "stats_dual_wield_pattern": "Alternância: {pattern}",
+  "stats_dual_wield_bonus": "Empunhadura Dupla: +10% Vel. de Ataque, +10% Bloqueio",
   "stats_increased_header": "Aumentado",
   "stats_increased_physical": "Físico",
   "stats_increased_cold": "Frio",

--- a/src/components/world/ShowStatsModal.tsx
+++ b/src/components/world/ShowStatsModal.tsx
@@ -3,6 +3,7 @@ import {
 	computeArmorMitigation,
 	computeEvasionAvoid,
 	effectiveCritChance,
+	isAttackDualWielding,
 	totalCritMultiplier,
 } from "#/game/stats/compute";
 import type { ComputedCharacterStats, SwingProfile } from "#/game/stats/types";
@@ -222,6 +223,11 @@ function OffenseSection({ stats }: { stats: ComputedCharacterStats }) {
 					{stats.swings.length > 1 && (
 						<p className="mt-2 text-xs text-white/40">
 							{m.stats_dual_wield_pattern({ pattern: swingsLabel })}
+						</p>
+					)}
+					{isAttackDualWielding(stats) && (
+						<p className="mt-1 text-xs text-yellow-300/80">
+							{m.stats_dual_wield_bonus()}
 						</p>
 					)}
 				</div>

--- a/src/game/combat/constants.ts
+++ b/src/game/combat/constants.ts
@@ -22,6 +22,13 @@ export const LEECH_CAP_PCT_MAX_LIFE_PER_SECOND = 0.2;
 export const MAX_POTIONS = 10;
 export const POTION_DROP_CHANCE = 0.2;
 
+// Attack dual-wielding implicit buffs (attack-1H + attack-1H only — wand+wand
+// is excluded). The AS buff is a "more" multiplier applied after the increased
+// pool, on top of the averaged base attack speed. The block bonus is additive
+// into the character's blockChance total (still bound by the 75% cap).
+export const DUAL_WIELD_AS_MORE_MULT = 1.1;
+export const DUAL_WIELD_BLOCK_CHANCE_BONUS = 10;
+
 // Travel consumables — vendor-only (no drops). Teleport stones instantly
 // return the player to the city; wind crystals jump to any previously-
 // unlocked node with a fixed travel duration (no MS scaling — you're

--- a/src/game/stats/compute.test.ts
+++ b/src/game/stats/compute.test.ts
@@ -6,6 +6,7 @@ import {
 	computeCharacterStats,
 	computeEvasionAvoid,
 	effectiveCritChance,
+	isAttackDualWielding,
 } from "./compute";
 import type { EquippedItem } from "./types";
 
@@ -177,7 +178,7 @@ describe("computeCharacterStats — equipment contributions", () => {
 		expect(stats.tickRate).toBeCloseTo(1.5);
 	});
 
-	it("dual-wielding two attack 1H weapons combines tick rate", () => {
+	it("attack dual-wielding averages the two weapons' speeds and applies +10% AS more multiplier", () => {
 		const eq: EquippedItem[] = [
 			{
 				slot: "weapon",
@@ -196,7 +197,45 @@ describe("computeCharacterStats — equipment contributions", () => {
 		expect(stats.swings).toHaveLength(2);
 		expect(stats.swings[0].source).toBe("mainHand");
 		expect(stats.swings[1].source).toBe("offHand");
-		expect(stats.tickRate).toBeCloseTo(1.5 + 1.6);
+		expect(isAttackDualWielding(stats)).toBe(true);
+		// avg(1.5, 1.6) × 1.10 = 1.55 × 1.10 = 1.705
+		expect(stats.tickRate).toBeCloseTo(1.705);
+	});
+
+	it("attack dual-wielding grants +10% block chance", () => {
+		const eq: EquippedItem[] = [
+			{
+				slot: "weapon",
+				item: sword("s1", { min: 5, max: 10, speed: 1.3, crit: 5 }),
+			},
+			{
+				slot: "offhand",
+				item: sword("s2", { min: 5, max: 10, speed: 1.3, crit: 5 }),
+			},
+		];
+		const stats = computeCharacterStats({
+			classDef: warrior,
+			level: 1,
+			equippedItems: eq,
+		});
+		expect(stats.blockChance).toBe(10);
+	});
+
+	it("single attack weapon does NOT receive DW buffs (no block, no AS more multiplier)", () => {
+		const eq: EquippedItem[] = [
+			{
+				slot: "weapon",
+				item: sword("s1", { min: 5, max: 10, speed: 1.5, crit: 8 }),
+			},
+		];
+		const stats = computeCharacterStats({
+			classDef: warrior,
+			level: 1,
+			equippedItems: eq,
+		});
+		expect(isAttackDualWielding(stats)).toBe(false);
+		expect(stats.blockChance).toBe(0);
+		expect(stats.tickRate).toBeCloseTo(1.5);
 	});
 
 	it("caster main hand sets path=spell and tick rate uses base cast speed (1.0)", () => {
@@ -210,6 +249,23 @@ describe("computeCharacterStats — equipment contributions", () => {
 		});
 		expect(stats.path).toBe("spell");
 		expect(stats.tickRate).toBe(1.0);
+	});
+
+	it("wand+wand dual-wields without receiving the attack-DW buffs", () => {
+		const eq: EquippedItem[] = [
+			{ slot: "weapon", item: wand("w1", { min: 4, max: 8 }) },
+			{ slot: "offhand", item: wand("w2", { min: 4, max: 8 }) },
+		];
+		const stats = computeCharacterStats({
+			classDef: mage,
+			level: 1,
+			equippedItems: eq,
+		});
+		expect(stats.swings).toHaveLength(2);
+		expect(isAttackDualWielding(stats)).toBe(false);
+		expect(stats.blockChance).toBe(0);
+		// avg(1.0, 1.0) with no DW more multiplier
+		expect(stats.tickRate).toBeCloseTo(1.0);
 	});
 
 	it("flat physical from gear adds onto attack swing damage", () => {

--- a/src/game/stats/compute.ts
+++ b/src/game/stats/compute.ts
@@ -504,6 +504,9 @@ function computeOnce(
 	const offHand = live.find((eq) => eq.slot === "offhand")?.item ?? null;
 	stats.path = determinePath(mainHand);
 	const offHandType = offHand?.weaponType;
+	// Source of truth for "is this attack dual-wielding?". The public
+	// `isAttackDualWielding(stats)` helper below re-derives the same answer from
+	// `path` + `swings.length` for UI consumers; both must agree.
 	const isAttackDW =
 		stats.path === "attack" &&
 		!!offHand &&
@@ -538,10 +541,9 @@ function computeOnce(
 			: 1 + stats.increased.attackSpeed / 100;
 	const swingCount = stats.swings.length;
 	const averagedBase =
-		swingCount === 0
-			? 0
-			: stats.swings.reduce((sum, s) => sum + s.baseAttackSpeed, 0) /
-				swingCount;
+		swingCount > 0
+			? stats.swings.reduce((sum, s) => sum + s.baseAttackSpeed, 0) / swingCount
+			: 0;
 	const dwMoreMult = isAttackDW ? DUAL_WIELD_AS_MORE_MULT : 1;
 	stats.tickRate = averagedBase * speedMultiplier * dwMoreMult;
 
@@ -618,6 +620,9 @@ export function effectiveCritChance(
 	return Math.min(CRIT_CHANCE_CAP, Math.max(CRIT_CHANCE_FLOOR, raw));
 }
 
+// Mirrors the internal `isAttackDW` check inside `computeOnce` — the engine
+// guarantees `swings.length === 2` iff attack DW is active, so this derives
+// the same answer for UI without re-reading the equipped items.
 export function isAttackDualWielding(stats: ComputedCharacterStats): boolean {
 	return stats.path === "attack" && stats.swings.length === 2;
 }

--- a/src/game/stats/compute.ts
+++ b/src/game/stats/compute.ts
@@ -1,5 +1,9 @@
 import type { CharacterClassDefinition } from "../classes/types";
-import { BASE_CAST_SPEED } from "../combat/constants";
+import {
+	BASE_CAST_SPEED,
+	DUAL_WIELD_AS_MORE_MULT,
+	DUAL_WIELD_BLOCK_CHANCE_BONUS,
+} from "../combat/constants";
 import type { GeneratedItem, RolledMod } from "../items/types";
 import type {
 	ComputedCharacterStats,
@@ -12,6 +16,7 @@ import type {
 // ── Caps ──
 
 const RESISTANCE_CAP = 75;
+const BLOCK_CHANCE_CAP = 75;
 const CRIT_CHANCE_CAP = 100;
 const CRIT_CHANCE_FLOOR = 5;
 const ARMOR_REDUCTION_CAP = 85;
@@ -458,7 +463,10 @@ function applyCaps(stats: ComputedCharacterStats): void {
 	r.fire = Math.min(RESISTANCE_CAP, Math.max(-100, r.fire));
 	r.lightning = Math.min(RESISTANCE_CAP, Math.max(-100, r.lightning));
 	r.void = Math.min(RESISTANCE_CAP, Math.max(-100, r.void));
-	stats.blockChance = Math.min(75, Math.max(0, stats.blockChance));
+	stats.blockChance = Math.min(
+		BLOCK_CHANCE_CAP,
+		Math.max(0, stats.blockChance),
+	);
 }
 
 // ── Requirements check ──
@@ -491,41 +499,51 @@ function computeOnce(
 	applyBase(stats, input.classDef, input.level);
 	for (const eq of live) applyItem(stats, pcts, eq.item);
 	foldGlobalDefenseIncreases(stats, pcts);
-	applyCaps(stats);
 
-	// Swing assembly
 	const mainHand = live.find((eq) => eq.slot === "weapon")?.item ?? null;
 	const offHand = live.find((eq) => eq.slot === "offhand")?.item ?? null;
 	stats.path = determinePath(mainHand);
+	const offHandType = offHand?.weaponType;
+	const isAttackDW =
+		stats.path === "attack" &&
+		!!offHand &&
+		!!offHandType &&
+		ATTACK_WEAPONS.has(offHandType);
+
+	// Apply DW block bonus before applyCaps so the 75% cap runs once.
+	if (isAttackDW) stats.blockChance += DUAL_WIELD_BLOCK_CHANCE_BONUS;
+	applyCaps(stats);
 
 	const gearFlat = collectGlobalFlatDamage(
 		live.filter((eq) => eq.slot !== "weapon" && eq.slot !== "offhand"),
 	);
 
-	const offHandType = offHand?.weaponType;
 	if (stats.path === "attack" && mainHand) {
 		stats.swings.push(buildSwing(mainHand, "mainHand", gearFlat, "attack"));
-		if (offHand && offHandType && ATTACK_WEAPONS.has(offHandType)) {
+		if (isAttackDW && offHand) {
 			stats.swings.push(buildSwing(offHand, "offHand", gearFlat, "attack"));
 		}
 	} else if (stats.path === "spell" && mainHand) {
 		stats.swings.push(buildSwing(mainHand, "mainHand", gearFlat, "spell"));
-		// Caster dual-wield: only wand+wand. Staves are 2H and can't sit in the
-		// off-hand slot, so we only accept "wand" specifically here.
+		// Staves are 2H and can't sit in the off-hand slot — only wand+wand.
+		// Caster dual-wield gets no implicits.
 		if (offHand && offHandType === "wand") {
 			stats.swings.push(buildSwing(offHand, "offHand", gearFlat, "spell"));
 		}
 	}
 
-	// Compute combined tick rate from the swings (each weapon at its own pace).
 	const speedMultiplier =
 		stats.path === "spell"
 			? 1 + stats.increased.castSpeed / 100
 			: 1 + stats.increased.attackSpeed / 100;
-	stats.tickRate = stats.swings.reduce(
-		(sum, s) => sum + s.baseAttackSpeed * speedMultiplier,
-		0,
-	);
+	const swingCount = stats.swings.length;
+	const averagedBase =
+		swingCount === 0
+			? 0
+			: stats.swings.reduce((sum, s) => sum + s.baseAttackSpeed, 0) /
+				swingCount;
+	const dwMoreMult = isAttackDW ? DUAL_WIELD_AS_MORE_MULT : 1;
+	stats.tickRate = averagedBase * speedMultiplier * dwMoreMult;
 
 	return stats;
 }
@@ -598,6 +616,10 @@ export function effectiveCritChance(
 ): number {
 	const raw = weaponCrit * (1 + globalIncrease / 100);
 	return Math.min(CRIT_CHANCE_CAP, Math.max(CRIT_CHANCE_FLOOR, raw));
+}
+
+export function isAttackDualWielding(stats: ComputedCharacterStats): boolean {
+	return stats.path === "attack" && stats.swings.length === 2;
 }
 
 export function totalCritMultiplier(bonusFromMods: number): number {

--- a/src/game/stats/types.ts
+++ b/src/game/stats/types.ts
@@ -117,7 +117,7 @@ export interface ComputedCharacterStats {
 	resistances: { cold: number; fire: number; lightning: number; void: number };
 
 	path: CombatPath;
-	/** Combined tick rate (sum of weapon speeds when dual-wielding). */
+	/** Combined tick rate. Dual-wielding uses the average of both weapons' base speeds (×1.10 more multiplier for attack DW). */
 	tickRate: number;
 	/** Swing profiles in tick alternation order. Length 1 = solo, 2 = dual-wield. */
 	swings: SwingProfile[];


### PR DESCRIPTION
## Summary

- Dual-wielding combat math changed from sum to **average** of both weapons' base attack speeds.
- Attack 1H + attack 1H gains **+10% AS** (more multiplier) and **+10% block chance** implicits. Wand+wand uses the average without buffs.
- New `isAttackDualWielding(stats)` helper for UI; no new field on the engine output (kept derivable from `path` + `swings`).
- `BLOCK_CHANCE_CAP = 75` extracted from magic numbers; DW bonus applied before `applyCaps` so the cap runs once.
- Show Stats panel surfaces the buff: yellow "Dual-Wielding: +10% AS, +10% Block" line under the swings.
- `CONTEXT.md` updated in three places: Per-tick attack, Block (no longer shield-only), Dual-wielding.

## Design intent

Existing DW felt strictly stronger than mh+shield. Average + small implicit pushes DW from "raw rate" toward "rate + light defense" so shield can hold its niche on block ceiling + thorns + a defensive slot. **Magnitude is a feel call**; may need iteration after playtest.

Numbers:
- Two 1.3 AS weapons: was `2.6` hits/s, now `avg(1.3,1.3) × 1.10 = 1.43` hits/s (~45% fewer hits).
- Asymmetric 2.0 + 1.2: was `3.2` hits/s, now `1.6 × 1.10 = 1.76` hits/s.

## Test plan

- [ ] Equip two 1H attack weapons and confirm Show Stats shows the "Dual-Wielding" line + +10% block in Defesas.
- [ ] Confirm combat tick rate visibly slower than pre-change DW (swings alternate at the averaged pace).
- [ ] Equip 1H attack + shield and confirm no DW bonus + shield block intact.
- [ ] Equip wand + wand and confirm no buffs (averaged cast speed only, no block, no DW bonus line).
- [ ] Verify the +10% block + any base block from shield (impossible combo, but the cap covers it) never exceeds 75%.
- [x] `npx vitest run` — 439/439 passing.
- [x] `npx tsc --noEmit` — clean.
- [x] `npx biome check` on touched files — clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)