### PR TITLE
feat: HUD visual polish — bigger combat buttons + text, smaller globe

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -55,7 +55,7 @@ The `/world` route shares a single shell (equipment panel + status card + log) a
 
 - **Map** — the act's node DAG. Default state when the player isn't inside any node. Equipment panel and status card (small HP globe, consumables, character info) remain visible on the right.
 - **City** — replaces the viewport with the city scene when the player enters a city node. No mobs. Surface includes buttons to open the **vendor** (modal) and the **stash** (modal). The status card and equipment panel are unchanged.
-- **Combat** — replaces the viewport with the active combat scene when the player enters a zone node. Enemy in center, enemy HP/name on top. The HP globe migrates from bottom-right (passive) to bottom-left (large, focal). Consumables remain usable.
+- **Combat** — replaces the viewport with the active combat scene when the player enters a zone node. Enemy in center, enemy HP/name on top. The HP globe migrates from bottom-right (passive) to bottom-left (prominent). Consumables remain usable.
 
 This is component-state inside `/world`, not three different routes. Entering a node sets the view mode; the "Back to map" affordance returns to **Map**.
 
@@ -275,7 +275,7 @@ Combat is otherwise automatic, but the player has **three active controls today*
 
 - **Life Potion**: heals **20% of maximum HP**. Cap 10 carried. Obtained from the city vendor (10 rubys) or as a 20% monster drop (see Loot Pipeline → Potion drops). Potion button lives on the bottom-right of the combat view (next to the health globe) and on the map's status card.
 - **Teleport Stone**: instant return to the city, usable from any view (combat included — panic button). Wipes the active zone bag (you escape but abandon the loot). Uncapped (stockpile what you can afford). Vendor-only, 30 rubys. Button sits to the left of the potion in the combat HUD.
-- **Wind Crystal**: jumps the player to any previously-unlocked node with a fixed travel duration (no movement-speed scaling — you're skipping zones, not walking through them). Uncapped. Vendor-only, 50 rubys. Used from the map view only (clicking an unlocked-but-unconnected node opens a confirmation). Counter sits above the teleport stone button in the combat HUD (display-only there; usage is map-only).
+- **Wind Crystal**: jumps the player to any previously-unlocked node with a fixed travel duration (no movement-speed scaling — you're skipping zones, not walking through them). Uncapped. Vendor-only, 50 rubys. Used from the map view only (clicking an unlocked-but-unconnected node opens a confirmation). Counter sits above the potion button in the combat HUD (display-only there; usage is map-only).
 
 The two travel consumables share the character document's `teleportStones` and `windCrystals` counters. The set of nodes available to wind crystals comes from `unlockedNodes` (see Travel system).
 

--- a/src/components/world/CombatScene.tsx
+++ b/src/components/world/CombatScene.tsx
@@ -62,9 +62,9 @@ export default function CombatScene({
 		<section className="relative flex flex-col overflow-hidden rounded-md border border-white/40 bg-black">
 			{/* Zone label + static zone level (the area's intrinsic difficulty;
 			 * the per-spawn monster level is shown separately on the nameplate). */}
-			<div className="absolute left-3 top-3 flex flex-col gap-0.5 text-sm uppercase tracking-[0.2em] text-white/60">
+			<div className="absolute left-3 top-3 flex flex-col gap-0.5 text-xl uppercase tracking-[0.2em] text-white/60">
 				<span>{zoneName}</span>
-				<span className="text-xs text-white/40">LV {zoneLevel}</span>
+				<span className="text-base text-white/40">LV {zoneLevel}</span>
 			</div>
 
 			{/* Top-right action cluster: loot button then Retreat */}
@@ -74,11 +74,11 @@ export default function CombatScene({
 					onClick={onOpenBag}
 					disabled={bagCount === 0}
 					aria-label={`Loot bag (${bagCount} items)`}
-					className="relative inline-flex items-center justify-center border border-white/40 bg-black p-1.5 text-white/80 transition hover:border-white hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-black"
+					className="relative inline-flex items-center justify-center border border-white/40 bg-black p-2.5 text-white/80 transition hover:border-white hover:bg-white/10 hover:text-white disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-black"
 				>
-					<Sparkles className="h-4 w-4" strokeWidth={2} />
+					<Sparkles className="h-5 w-5" strokeWidth={2} />
 					{bagCount > 0 && (
-						<span className="absolute -top-1.5 -right-1.5 min-w-[1.1rem] border border-white bg-black px-1 text-center font-bold text-[10px] text-white leading-tight">
+						<span className="absolute -top-1.5 -right-1.5 min-w-[1.25rem] border border-white bg-black px-1 text-center font-bold text-xs text-white leading-tight">
 							{bagCount}
 						</span>
 					)}
@@ -87,21 +87,21 @@ export default function CombatScene({
 					type="button"
 					onClick={onRetreat}
 					aria-label={m.retreat_to_map()}
-					className="inline-flex items-center gap-1.5 border border-white/40 bg-black px-3 py-1.5 font-medium text-[10px] text-white/80 uppercase tracking-wider transition hover:border-white hover:bg-white/10 hover:text-white"
+					className="inline-flex items-center gap-2 border border-white/40 bg-black px-4 py-2.5 font-medium text-sm text-white/80 uppercase tracking-wider transition hover:border-white hover:bg-white/10 hover:text-white"
 				>
-					<ArrowLeft className="h-3.5 w-3.5" strokeWidth={2} />
+					<ArrowLeft className="h-5 w-5" strokeWidth={2} />
 					{m.retreat()}
 				</button>
 			</div>
 
 			{/* Enemy nameplate: name on top, level directly below */}
-			<div className="flex flex-col items-center gap-1 px-6 pt-12">
+			<div className="flex flex-col items-center gap-1 px-6 pt-14">
 				{enemy ? (
 					<>
-						<div className="display-title text-2xl uppercase tracking-[0.15em] text-white">
+						<div className="display-title text-4xl uppercase tracking-[0.15em] text-white">
 							{enemy.def.name}
 						</div>
-						<div className="text-sm uppercase tracking-[0.2em] text-white/60">
+						<div className="text-lg uppercase tracking-[0.2em] text-white/60">
 							Lv {enemy.level}
 						</div>
 					</>
@@ -148,10 +148,10 @@ export default function CombatScene({
 				)}
 			</div>
 
-			{/* Bottom HUD: HP globe + XP bar + potion button */}
+			{/* Bottom HUD: HP globe + XP bar + teleport stone + (wind-crystal counter / potion) */}
 			<div className="relative flex items-center gap-4 border-t border-white/15 bg-black/60 p-4">
 				<div className="relative">
-					<HealthGlobe hp={playerHp} maxHp={maxHp} size="lg" />
+					<HealthGlobe hp={playerHp} maxHp={maxHp} size="md" />
 					{/* Damage popups over the globe */}
 					<div className="pointer-events-none absolute inset-0 flex items-center justify-center">
 						<AnimatePresence>
@@ -181,24 +181,16 @@ export default function CombatScene({
 					</div>
 				</div>
 
-				{/* Consumable cluster: wind-crystal counter pinned above the
-				 * teleport-stone button (display-only counter), teleport stone
-				 * button (panic-return-to-city), potion button (heal). Order
-				 * left → right roughly matches "how often used". */}
+				{/* Teleport stone wears an invisible counter above so its base
+				 * aligns with the potion (which carries the visible counter). */}
 				<div className="flex flex-col items-center gap-1">
-					<div
-						className="display-title flex items-center gap-1 border border-white/30 bg-black px-1.5 py-0.5 text-[10px] tracking-wider text-white/80"
-						aria-label={`${windCrystals} wind crystals`}
-					>
-						<span aria-hidden="true">💎</span>
-						<span className="tabular-nums">{windCrystals}</span>
-					</div>
+					<WindCrystalCounter count={windCrystals} hidden />
 					<button
 						type="button"
 						onClick={onUseTeleportStone}
 						disabled={!canUseTeleportStone}
 						aria-label="Use teleport stone"
-						className="relative flex h-12 w-12 shrink-0 items-center justify-center border border-white/40 bg-black text-xl transition hover:border-white hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-black"
+						className="relative flex h-20 w-20 shrink-0 items-center justify-center border border-white/40 bg-black text-3xl transition hover:border-white hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-black"
 					>
 						🪨
 						<span className="absolute -bottom-1.5 -right-1.5 min-w-[1.25rem] border border-white/40 bg-black px-1 text-center text-[10px] leading-tight text-white">
@@ -207,20 +199,48 @@ export default function CombatScene({
 					</button>
 				</div>
 
-				<button
-					type="button"
-					onClick={onUsePotion}
-					disabled={!canUsePotion}
-					aria-label="Use potion"
-					className="relative flex h-14 w-14 shrink-0 items-center justify-center border border-white/40 bg-black text-2xl transition hover:border-white hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-black"
-				>
-					🧪
-					<span className="absolute -bottom-1.5 -right-1.5 min-w-[1.25rem] border border-white/40 bg-black px-1 text-center text-[10px] leading-tight text-white">
-						{potions}
-					</span>
-				</button>
+				{/* Wind-crystal usage is map-only; here the counter is just a readout. */}
+				<div className="flex flex-col items-center gap-1">
+					<WindCrystalCounter count={windCrystals} />
+					<button
+						type="button"
+						onClick={onUsePotion}
+						disabled={!canUsePotion}
+						aria-label="Use potion"
+						className="relative flex h-20 w-20 shrink-0 items-center justify-center border border-white/40 bg-black text-3xl transition hover:border-white hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-black"
+					>
+						🧪
+						<span className="absolute -bottom-1.5 -right-1.5 min-w-[1.25rem] border border-white/40 bg-black px-1 text-center text-[10px] leading-tight text-white">
+							{potions}
+						</span>
+					</button>
+				</div>
 			</div>
 		</section>
+	);
+}
+
+// Rendered in both consumable columns so the teleport-stone button's baseline
+// matches the potion's (which carries the visible counter). The `hidden`
+// variant uses `invisible` rather than conditional rendering so the spacer
+// always matches the real counter's height — no drift possible.
+function WindCrystalCounter({
+	count,
+	hidden = false,
+}: {
+	count: number;
+	hidden?: boolean;
+}) {
+	return (
+		<div
+			role="img"
+			aria-label={`${count} wind crystals`}
+			aria-hidden={hidden || undefined}
+			className={`display-title flex items-center gap-1 text-sm tracking-wider text-white ${hidden ? "invisible" : ""}`}
+		>
+			<span aria-hidden="true">💎</span>
+			<span className="tabular-nums">×{count}</span>
+		</div>
 	);
 }
 

--- a/src/components/world/HealthGlobe.tsx
+++ b/src/components/world/HealthGlobe.tsx
@@ -2,7 +2,13 @@ type Props = {
 	hp: number;
 	maxHp: number;
 	barrier?: number;
-	size?: "sm" | "lg";
+	size?: "sm" | "md" | "lg";
+};
+
+const SIZE_CLASSES: Record<NonNullable<Props["size"]>, string> = {
+	sm: "h-16 w-16 text-[10px]",
+	md: "h-24 w-24 text-sm",
+	lg: "h-28 w-28 text-sm",
 };
 
 export default function HealthGlobe({
@@ -11,8 +17,7 @@ export default function HealthGlobe({
 	barrier = 0,
 	size = "sm",
 }: Props) {
-	const dimensions =
-		size === "lg" ? "h-28 w-28 text-sm" : "h-16 w-16 text-[10px]";
+	const dimensions = SIZE_CLASSES[size];
 	const pct = maxHp > 0 ? Math.max(0, Math.min(100, (hp / maxHp) * 100)) : 0;
 
 	return (
@@ -28,11 +33,11 @@ export default function HealthGlobe({
 				aria-hidden
 			/>
 
-			<span className="relative z-10 font-bold leading-tight text-white drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)]">
+			<span className="relative z-10 font-bold leading-tight text-white">
 				{Math.ceil(hp)}/{maxHp}
 			</span>
 			{barrier > 0 && (
-				<span className="relative z-10 text-[0.85em] leading-tight text-white/80 drop-shadow-[0_1px_2px_rgba(0,0,0,0.8)]">
+				<span className="relative z-10 text-[0.85em] leading-tight text-white/80">
 					{barrier}/{barrier}
 				</span>
 			)}

--- a/src/components/world/StatusCard.tsx
+++ b/src/components/world/StatusCard.tsx
@@ -76,23 +76,23 @@ export default function StatusCard({
 			<div className="flex flex-col gap-3">
 				<div className="grid grid-cols-2 gap-4">
 					<div className="min-w-0">
-						<h3 className="display-title truncate text-xl uppercase tracking-wider text-white">
+						<h3 className="display-title truncate text-2xl uppercase tracking-wider text-white">
 							{character.name}
 						</h3>
-						<p className="mt-1 text-sm text-white/80">
+						<p className="mt-1 text-lg text-white/80">
 							<span className="text-white/50">{m.status_class_label()}</span>{" "}
 							{classResolved}
 						</p>
-						<p className="text-sm text-white/80">
+						<p className="text-lg text-white/80">
 							<span className="text-white/50">{m.status_level_label()}</span>{" "}
 							{character.level}
 						</p>
-						<p className="text-sm text-white/80">
+						<p className="text-lg text-white/80">
 							<span className="text-white/50">{m.status_dps_label()}</span>{" "}
 							{dps > 0 ? dps : "—"}
 						</p>
 					</div>
-					<div className="display-title space-y-1.5 text-right text-base tracking-wider">
+					<div className="display-title space-y-1.5 text-right text-xl tracking-wider">
 						<p className="text-glow-red">
 							{m.status_strength_label()} {stats.attributes.strength}
 						</p>
@@ -107,7 +107,7 @@ export default function StatusCard({
 
 				<div className="flex items-center gap-3">
 					<div className="flex-1 space-y-1">
-						<div className="text-[10px] uppercase tracking-wider text-yellow-300/80">
+						<div className="text-sm uppercase tracking-wider text-yellow-300/80">
 							{m.status_xp_label({ current: xp, needed: xpNeeded })}
 						</div>
 						<div
@@ -129,10 +129,10 @@ export default function StatusCard({
 						onClick={onUsePotion}
 						disabled={!canUsePotion}
 						aria-label="Use potion"
-						className="relative flex h-10 w-10 shrink-0 items-center justify-center border border-white/40 bg-black text-base transition hover:border-white hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-black"
+						className="relative flex h-16 w-16 shrink-0 items-center justify-center border border-white/40 bg-black text-2xl transition hover:border-white hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-40 disabled:hover:bg-black"
 					>
 						🧪
-						<span className="absolute -bottom-1 -right-1 min-w-[1rem] border border-white/40 bg-black px-1 text-center text-[9px] leading-tight text-white">
+						<span className="absolute -bottom-1.5 -right-1.5 min-w-[1.25rem] border border-white/40 bg-black px-1 text-center text-xs leading-tight text-white">
 							{potions}
 						</span>
 					</button>
@@ -162,10 +162,10 @@ export default function StatusCard({
 							onClick={onUseTeleportStone}
 							disabled={!canUseTeleportStone}
 							aria-label="Use teleport stone"
-							className="relative flex h-12 w-12 items-center justify-center border border-white/30 bg-black/60 text-xs font-bold uppercase tracking-wider text-white/60 transition hover:border-white hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-white/30 disabled:hover:bg-black/60"
+							className="relative flex h-16 w-16 items-center justify-center border border-white/30 bg-black/60 text-2xl font-bold uppercase tracking-wider text-white/60 transition hover:border-white hover:bg-white/10 disabled:cursor-not-allowed disabled:opacity-60 disabled:hover:border-white/30 disabled:hover:bg-black/60"
 						>
 							🪨
-							<span className="absolute -bottom-1 -right-1 min-w-[1.25rem] border border-white/40 bg-black px-1 text-center text-[10px] leading-tight text-white">
+							<span className="absolute -bottom-1.5 -right-1.5 min-w-[1.25rem] border border-white/40 bg-black px-1 text-center text-xs leading-tight text-white">
 								{teleportStones}
 							</span>
 						</button>
@@ -181,9 +181,9 @@ export default function StatusCard({
 
 function ConsumableSlot({ label, count }: { label: string; count: number }) {
 	return (
-		<div className="relative flex h-12 w-12 items-center justify-center border border-white/30 bg-black/60 text-xs font-bold uppercase tracking-wider text-white/60">
+		<div className="relative flex h-16 w-16 items-center justify-center border border-white/30 bg-black/60 text-2xl font-bold uppercase tracking-wider text-white/60">
 			{label}
-			<span className="absolute -bottom-1 -right-1 min-w-[1.25rem] border border-white/40 bg-black px-1 text-center text-[10px] leading-tight text-white">
+			<span className="absolute -bottom-1.5 -right-1.5 min-w-[1.25rem] border border-white/40 bg-black px-1 text-center text-xs leading-tight text-white">
 				×{count}
 			</span>
 		</div>

--- a/src/components/world/VendorModal.tsx
+++ b/src/components/world/VendorModal.tsx
@@ -119,9 +119,12 @@ export default function VendorModal({
 			className="max-w-4xl"
 		>
 			<div className="space-y-5">
-				{/* Header row: tab strip on the left, ruby balance on the right */}
-				<div className="flex items-center justify-between">
-					<div className="flex gap-6 border-white/15 border-b">
+				{/* Header row: centered tab strip with ruby balance pinned right.
+				 * 3-col grid keeps the tabs visually centered in the modal width
+				 * regardless of how wide the balance grows. */}
+				<div className="grid grid-cols-3 items-center">
+					<div />
+					<div className="flex justify-center gap-6 border-white/15 border-b">
 						<TabButton active={tab === "buy"} onClick={() => setTab("buy")}>
 							{m.vendor_tab_buy()}
 						</TabButton>
@@ -132,7 +135,7 @@ export default function VendorModal({
 							{m.vendor_tab_sell()}
 						</TabButton>
 					</div>
-					<div className="display-title relative flex items-center gap-2 px-1 text-xl uppercase tracking-[0.15em] text-yellow-300 tabular-nums">
+					<div className="display-title relative flex items-center justify-end gap-2 px-1 text-xl uppercase tracking-[0.15em] text-yellow-300 tabular-nums">
 						<Gem className="h-5 w-5 text-rose-400" strokeWidth={2} />
 						{rubys}
 						{/* Floating deltas — pinned just above the balance, animate up


### PR DESCRIPTION
## Summary

Visual pass on the combat HUD and status card, plus a small fix to vendor-modal tab alignment. Cherry-picked from PR #27 (which was opened against `feat/consumables` by mistake) so it lands on `master` directly.

- **Combat HUD:** HP globe shrunk from `lg` (h-28) to a new `md` size (h-24). Zone label, enemy nameplate, loot button, and retreat button all bumped for legibility. Consumable cluster reshuffled: 🪨 teleport stone is now its own column at `h-20`; the 💎 wind-crystal counter moved out from above 🪨 and into a borderless `💎 ×N` display sitting above the 🧪 potion. Both buttons share aligned baselines via a shared `WindCrystalCounter` component (rendered visibly above potion, invisibly above teleport — no class-drift risk).
- **StatusCard:** uniform text bump (`text-sm`→`text-lg`, attribute block `text-base`→`text-xl`, etc.). Potion, teleport, and consumable slot all unified at `h-16`. SHOW button kept at its current size.
- **HealthGlobe:** added `md` size to the size lookup; removed the always-on `drop-shadow` on the HP/barrier numbers (cleaner numbers + a paint-cost win on the per-tick re-render).
- **VendorModal:** swapped the header `flex justify-between` for a 3-col grid so the buy/sell tab strip stays visually centered while the ruby balance remains pinned right.
- **CONTEXT.md:** glossary aligned — HP globe in combat is now described as "prominent" instead of "large, focal"; wind-crystal counter line updated to "above the potion button".

## Test plan

- [ ] Enter a zone and verify combat HUD: globe sits slightly larger than buttons (h-24 vs h-20), 🪨 and 🧪 share the same baseline, 💎 ×N reads cleanly above 🧪 without a border
- [ ] Confirm zone name + enemy name + retreat/loot buttons are noticeably more legible at typical viewport sizes
- [ ] Open the world status card on the map: text scales up evenly, all three consumable cells (🧪/🪨/💎) are uniform h-16
- [ ] Open the vendor modal: buy/sell tabs are centered horizontally regardless of ruby balance width
- [ ] Verify the world view still fits without scroll (per CONTEXT.md UI invariant)

🤖 Generated with [Claude Code](https://claude.com/claude-code)