### PR TITLE
feat: promote off-hand weapon when main hand is unequipped

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -562,6 +562,7 @@ A second one-handed weapon may go in the off-hand slot. When both hands hold a w
 - One-handed caster (`wand`) can occupy main hand **or** off-hand.
 - Two-handed weapons (`greatsword`, `twoHandedAxe`, `bow`, `staff`) occupy main hand **and block the off-hand slot** — equipping a 2H weapon while an off-hand item is equipped auto-unequips the off-hand back to inventory.
 - Shields are off-hand only.
+- **If the main hand is empty, the off-hand cannot hold a weapon.** Unequipping the main hand while the off-hand holds a weapon promotes the off-hand into the main-hand slot (the off-hand slot then becomes empty). Symmetric to the 2H rule above. Shields stay in the off-hand when the main hand is empty — a shield is defensive only and can't be promoted.
 
 **Same-archetype rule**: dual-wielding requires both weapons to share archetype. Attack 1H + attack 1H is allowed (sword + dagger, axe + sword, etc.). Caster 1H + caster 1H is allowed (wand + wand — the only caster combination). **Mixed archetype is rejected** (no sword + wand). This keeps the combat tick model coherent — one path (attack or spell) active at a time.
 

--- a/convex/items.ts
+++ b/convex/items.ts
@@ -313,6 +313,16 @@ export const unequipItem = mutation({
 		const item = equipped.find((it) => it.equippedSlot === args.slot)
 		if (!item) throw new ConvexError("Slot is empty")
 
+		// Invariant: if main hand is empty, off-hand cannot hold a weapon.
+		// Capture the off-hand weapon now, before any patches, so the promotion
+		// below operates on a clean pre-mutation snapshot.
+		const offhandToPromote =
+			args.slot === "weapon"
+				? equipped.find(
+						(it) => it.equippedSlot === "offhand" && isWeapon(it.data),
+					)
+				: undefined
+
 		const { used, nextFreeSlot } = await fetchInventoryAllocator(
 			ctx,
 			args.characterId,
@@ -326,15 +336,10 @@ export const unequipItem = mutation({
 			inventorySlot: nextFreeSlot(),
 		})
 
-		// Invariant: if main hand is empty, off-hand cannot hold a weapon.
-		// Promote the off-hand weapon into the main-hand slot. Shields stay.
-		if (args.slot === "weapon") {
-			const offhand = equipped.find((it) => it.equippedSlot === "offhand")
-			if (offhand && isWeapon(offhand.data)) {
-				await ctx.db.patch(offhand._id, {
-					equippedSlot: "weapon" as const,
-				})
-			}
+		if (offhandToPromote) {
+			await ctx.db.patch(offhandToPromote._id, {
+				equippedSlot: "weapon" as const,
+			})
 		}
 
 		return { unequipped: 1 }

--- a/convex/items.ts
+++ b/convex/items.ts
@@ -1,7 +1,7 @@
 import { ConvexError, v } from "convex/values"
 import { findClassDefinition } from "../src/game/classes/data"
 import { INVENTORY_MAX_SLOTS } from "../src/game/inventory/constants"
-import { planEquip } from "../src/game/items/equipment"
+import { isWeapon, planEquip } from "../src/game/items/equipment"
 import { computeCharacterStats } from "../src/game/stats/compute"
 import { type EquippedItem, narrowEquippedSlot } from "../src/game/stats/types"
 import {
@@ -325,6 +325,18 @@ export const unequipItem = mutation({
 			equippedSlot: undefined,
 			inventorySlot: nextFreeSlot(),
 		})
+
+		// Invariant: if main hand is empty, off-hand cannot hold a weapon.
+		// Promote the off-hand weapon into the main-hand slot. Shields stay.
+		if (args.slot === "weapon") {
+			const offhand = equipped.find((it) => it.equippedSlot === "offhand")
+			if (offhand && isWeapon(offhand.data)) {
+				await ctx.db.patch(offhand._id, {
+					equippedSlot: "weapon" as const,
+				})
+			}
+		}
+
 		return { unequipped: 1 }
 	},
 })

--- a/src/components/world/InventoryModal.tsx
+++ b/src/components/world/InventoryModal.tsx
@@ -236,7 +236,22 @@ export default function InventoryModal({
 					inventorySlot: firstFree,
 				},
 			].sort(bySlotAsc);
-			const newEquipped = equipped.filter((it) => it._id !== item._id);
+			let newEquipped = equipped.filter((it) => it._id !== item._id);
+
+			// Invariant: main hand empty → off-hand cannot hold a weapon.
+			// Promote off-hand weapon into the main-hand slot.
+			if (args.slot === "weapon") {
+				const offhand = newEquipped.find(
+					(it) => it.equippedSlot === "offhand",
+				);
+				if (offhand && isWeapon(offhand.data)) {
+					newEquipped = newEquipped.map((it) =>
+						it._id === offhand._id
+							? { ...it, equippedSlot: "weapon" as const }
+							: it,
+					);
+				}
+			}
 
 			localStore.setQuery(
 				api.items.inventory,


### PR DESCRIPTION
## Summary

- Establishes a new domain invariant in `CONTEXT.md`: **if the main hand is empty, the off-hand cannot hold a weapon** — symmetric to the existing 2H rule.
- Enforces the invariant in `unequipItem` (`convex/items.ts`): when the main hand is removed while the off-hand holds a weapon, the off-hand is slot-moved into the main-hand slot in the same handler. Shields stay (defensive only).
- Mirrors the promotion in the `withOptimisticUpdate` for `unequipItem` in `InventoryModal.tsx` so the swap is visible before the round-trip.

### Why
Previously, unequipping the main hand while dual-wielding left the off-hand orphaned and the player stopped dealing damage (the combat loop reads the weapon slot for swings). Promotion makes the intent ("I want to swap out my main weapon") work as expected — the secondary weapon takes over.

### Design notes (decided during grilling)
- **Slot move, not re-equip.** No fresh equip-time check is run on the promoted weapon. If a requirement is now unmet (e.g. the unequipped main was supplying STR), broken-state handles it via the stat engine — no surprise eviction to inventory.
- **Silent.** The visual cue is the slot move itself — no toast, no animation.
- **Server-only enforcement point.** `equipItem`, `pickFromBag`, etc. can never produce the violated state, so the normalization lives in `unequipItem` (the only path that can).

## Test plan
- [ ] Equip sword in main + dagger in off, click "Desequipar" on main → dagger moves to main, off-hand empty.
- [ ] Equip wand + wand, unequip main → off-hand wand promotes (caster archetype works the same).
- [ ] Equip sword + shield, unequip main → shield stays in off-hand (no promotion).
- [ ] Equip 2H (greatsword), unequip → off-hand stays empty (no spurious promotion).
- [ ] Drag main hand from paper-doll to inventory grid → same promotion fires (same mutation).
- [ ] Mid-combat unequip main while dual-wielding → combat keeps swinging with the promoted weapon next tick.
- [ ] Inventory full (60 used) + dual-wielding, unequip main → server rejects (`Inventory full`), nothing changes.
- [ ] Promoted weapon ends up broken (requirement unmet) → renders with red border + AlertTriangle, no swings (stat engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)