### PR TITLE
Early-game polish + time-based zone design

### DIFF
--- a/.claude/skills/simplify/SKILL.md
+++ b/.claude/skills/simplify/SKILL.md
@@ -1,0 +1,55 @@
+---
+name: simplify
+description: Review changed files for reuse, code quality, and efficiency, then fix cleanup issues directly. Use when the user asks to simplify, clean up, or review changed code for reusable utilities, hacky patterns, and performance problems.
+---
+
+# Simplify: Code Review and Cleanup
+
+Review all changed files for reuse, quality, and efficiency. Fix any issues found.
+
+## Phase 1: Identify Changes
+
+Run git diff (or git diff HEAD if there are staged changes) to see what changed. If there are no git changes, review the most recently modified files that the user mentioned or that you edited earlier in this conversation.
+
+## Phase 2: Launch Three Review Agents in Parallel
+
+Use the Agent tool to launch all three agents concurrently in a single message. Pass each agent the full diff so it has the complete context.
+
+### Agent 1: Code Reuse Review
+
+For each change:
+
+- Search for existing utilities and helpers that could replace newly written code. Look for similar patterns elsewhere in the codebase — common locations are utility directories, shared modules, and files adjacent to the changed ones.
+- Flag any new function that duplicates existing functionality. Suggest the existing function to use instead.
+- Flag any inline logic that could use an existing utility — hand-rolled string manipulation, manual path handling, custom environment checks, ad-hoc type guards, and similar patterns are common candidates.
+
+### Agent 2: Code Quality Review
+
+Review the same changes for hacky patterns:
+
+- Redundant state: state that duplicates existing state, cached values that could be derived, observers/effects that could be direct calls
+- Parameter sprawl: adding new parameters to a function instead of generalizing or restructuring existing ones
+- Copy-paste with slight variation: near-duplicate code blocks that should be unified with a shared abstraction
+- Leaky abstractions: exposing internal details that should be encapsulated, or breaking existing abstraction boundaries
+- Stringly-typed code: using raw strings where constants, enums (string unions), or branded types already exist in the codebase
+- Unnecessary JSX nesting: wrapper Boxes/elements that add no layout value — check if inner component props (flexShrink, alignItems, etc.) already provide the needed behavior
+- Nested conditionals: ternary chains (a ? x : b ? y : ...), nested if/else, or nested switch 3+ levels deep — flatten with early returns, guard clauses, a lookup table, or an if/else-if cascade
+- Unnecessary comments: comments explaining WHAT the code does (well-named identifiers already do that), narrating the change, or referencing the task/caller — delete; keep only non-obvious WHY (hidden constraints, subtle invariants, workarounds)
+
+### Agent 3: Efficiency Review
+
+Review the same changes for efficiency:
+
+- Unnecessary work: redundant computations, repeated file reads, duplicate network/API calls, N+1 patterns
+- Missed concurrency: independent operations run sequentially when they could run in parallel
+- Hot-path bloat: new blocking work added to startup or per-request/per-render hot paths
+- Recurring no-op updates: state/store updates inside polling loops, intervals, or event handlers that fire unconditionally — add a change-detection guard so downstream consumers aren't notified when nothing changed. Also: if a wrapper function takes an updater/reducer callback, verify it honors same-reference returns (or whatever the "no change" signal is) — otherwise callers' early-return no-ops are silently defeated
+- Unnecessary existence checks: pre-checking file/resource existence before operating (TOCTOU anti-pattern) — operate directly and handle the error
+- Memory: unbounded data structures, missing cleanup, event listener leaks
+- Overly broad operations: reading entire files when only a portion is needed, loading all items when filtering for one
+
+## Phase 3: Fix Issues
+
+Wait for all three agents to complete. Aggregate their findings and fix each issue directly. If a finding is a false positive or not worth addressing, note it and move on — do not argue with the finding, just skip it.
+
+When done, briefly summarize what was fixed (or confirm the code was already clean).

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -15,28 +15,67 @@ A central screen that lets the player switch between unlocked acts to farm them 
 ### Node
 A point in the act's DAG. Two kinds exist today:
 
-- **Zone node** — a combat location. The player enters, fights enemies (see Threshold Bar / Zone Boss), leaves, returns later. May be a regular zone, the act-boss node, or future variants.
+- **Zone node** — a combat location. The player enters, fights enemies (see Time Bar / Zone Miniboss), leaves, returns later. May be a regular zone, the act-boss node, or future variants.
 - **City node** — a safe location with no mobs. Houses the act's **vendor** and gives access to the **stash**. Always one city per act, unlocked at act entry (the player starts the act with both the city node and the first zone node visible on the map).
 
 ### Zone
 Synonym for a Zone node. Used in the rest of this document when the distinction from a city is contextual.
 
 A zone has persistent states per character:
-- **Incomplete** — never finished. Threshold bar resets every time the player leaves.
-- **Complete** — the player killed the zone miniboss at least once. Stays this way forever. Re-entering the zone is allowed for farming; the miniboss can be summoned again by refilling the threshold.
+- **Incomplete** — never finished. Time bar resets every time the player leaves.
+- **Complete** — the player killed the zone miniboss at least once. Stays this way forever. Re-entering the zone is allowed for farming; the miniboss can be summoned again by completing the encounter schedule.
 
-A future **Boss pending** state is planned (see "Boss Deferral" below) but not implemented yet — today the threshold filling spawns the miniboss immediately, no pause modal.
+A future **Boss pending** state is planned (see "Boss Deferral" below) but not implemented yet — today the bar filling spawns the miniboss immediately, no pause modal.
 
-### Threshold Bar
-The progress bar shown over the zone view that fills as the player kills mobs. The exact kill count is hidden; only the bar is visible. The threshold is **30 kills**. When it fills, the **next mob spawn is the zone miniboss** (or, in a future iteration, becomes summonable — see "Boss Deferral"). The fill resets to 0 every time the player leaves the zone with the miniboss unsummoned, and also resets to 0 immediately after a miniboss kill so the farming loop can refill.
+### Time Bar
+The progress bar shown over the zone view that represents the player's transit through the zone. The bar advances only during **exploração** (gaps between encounters); it pauses during **combate** and during **acampamento**. When the bar fills (the zone's encounter schedule completes), the **next spawn is the zone miniboss** (or, in a future iteration, becomes summonable — see "Boss Deferral").
+
+The fill resets to 0 every time the player leaves the zone with the miniboss unsummoned, and resets to 0 immediately after a miniboss kill so the farming loop can refill on the next entry.
+
+The bar UI displays the player's progress through the schedule (cumulative exploration time over total scheduled exploration time). The exact remaining time is hidden; only the bar is visible.
+
+### Combat Phases
+Three distinct phases a player can be in inside a zone. They determine the bag retention rules on exit (see Loot Pipeline → Bag retention tiers):
+
+- **Combate** — an enemy is active and the combat tick is running. Player swings, enemy swings, damage is applied.
+- **Exploração** — no enemy on screen, the time bar is advancing. Conceptually, the player is "walking through the zone".
+- **Acampamento** — bar paused, cinematic + modal active. The player is at a safe rest point (either baked into the zone schedule, or summoned via Incenso Etéreo).
+
+### Encounter Schedule
+Each zone declares how many encounters its bar contains and how those encounters are paced. The schedule is generated per entry — every visit rolls a new variation:
+
+- **Encounter count** scales with the zone's position in the act: ~15 in entry zones (forest_starter), ramping up to ~30 in zones adjacent to the boss node.
+- **Gap between normal spawns** is random within zone-declared bounds (e.g., 3–9 seconds of exploration).
+- **Ambush events** are deliberate packs of mobs inserted at random positions in the schedule (1–2 per zone). Each pack is 3–5 mobs back-to-back with very short gaps (~0.8s), heavy magic-rarity rate. Packs interrupt the normal cadence; the UI signals an ambush moment.
+- **Camp positions** are anchored proportionally to schedule length with a small jitter (±1 slot):
+  - `< 20` encounters → 1 camp anchored at ~50%
+  - `≥ 20` encounters → 2 camps anchored at ~33% and ~66%
+- After all scheduled encounters are consumed, the next spawn is the zone miniboss.
+
+The schedule lives as data per zone (`src/game/world/act-1.ts`). The combat engine reads and dispatches events; spawn mechanics use an abstract `spawn event` shape (e.g., `{ size: 1, kind, ... }`) so future multi-enemy combat (NvN) can plug `size: N` ambush events without changing the engine surface.
+
+### Acampamento
+A guaranteed rest point inside the zone. When the schedule reaches a camp slot, in place of the next spawn, the engine triggers a **camp cinematic**: the combat HUD fades out, ambient text fades in (zone-themed: e.g., "Sons da natureza calma...", "Um vento corre...", "O ar fica mais leve."), and finally a modal opens with two options:
+
+- **Retornar à cidade com 100% do loot** — exits the zone via the standard `ExitZoneModal` with the full bag selectable. Player picks freely; nothing is capped or random.
+- **Seguir em frente** — closes the modal; the bar resumes from where it was, the next scheduled encounter spawns. Zone progress is preserved.
+
+Mechanical side effects during the camp:
+- Bar is paused.
+- Passive HP regen and barrier recovery tick naturally during the cinematic and modal time (no special "rest" UI — it's a side effect of being out of combat).
+- The bag is preserved as-is until the player commits to either option.
+
+Camps are the **only** path to retreating with 100% of the bag outside of a boss kill. This is the central economy lever of zone progression: planning around camp positions matters.
+
+A future audio layer will play biome-specific ambient sounds during the cinematic (the project already has hit-sound infra to build on). Until that layer ships, the cinematic is text + fade only.
 
 ### Boss Deferral (planned, not implemented)
-When the threshold bar fills, a pause modal will ask if the player wants to fight the boss now. If they decline, a persistent **"Invoke Boss"** button will appear in the zone UI. This button will survive leaving and re-entering the zone — the boss stays "pending" until killed. Until this lands, the threshold-fill spawn happens automatically on the next mob roll.
+When the time bar fills, a pause modal will ask if the player wants to fight the boss now. If they decline, a persistent **"Invoke Boss"** button will appear in the zone UI. This button will survive leaving and re-entering the zone — the boss stays "pending" until killed. Until this lands, the bar-fill spawn happens automatically on the next mob roll.
 
 ### Zone Miniboss
-A **rare-rarity** monster that spawns at the threshold of a normal zone. Picked uniformly from the zone's `monsterPool` and promoted to rare with 3 random modifiers (see Monster Modifier Pool). Drops better loot than mobs — see drop table. Respawns every time the threshold is refilled, including after the zone is complete (so completed zones remain meaningful for loot farming).
+A **rare-rarity** monster that spawns when the time bar fills in a normal zone. Picked uniformly from the zone's `monsterPool` and promoted to rare with 3 random modifiers (see Monster Modifier Pool). Drops better loot than mobs — see drop table. Respawns every time the bar is filled again, including after the zone is complete (so completed zones remain meaningful for loot farming).
 
-After a miniboss kill the combat scene shows an inline "Zone Complete" panel where the enemy was: **continue farming** (combat resumes, threshold resets) or **retreat** (standard exit-zone flow with the loot picker).
+After a miniboss kill the combat scene shows an inline "Zone Complete" panel where the enemy was: **continue farming** (combat resumes, the bar resets to 0 and the schedule is rerolled) or **retreat** (standard exit-zone flow with the loot picker).
 
 ### Act Boss
 A distinct, more powerful enemy that gates progression to the next act. Lives in the **final node** of the act (a dedicated boss node, not a regular zone). For Act 1, the boss node follows **Model B**:
@@ -134,12 +173,27 @@ When a mob is killed, server rolls drops using:
 ### Potion drops
 Independent of the equipment drop roll, every monster kill rolls a **20% chance to drop a life potion**. Potions are not entities in the items table — they are a count on the character doc — so the drop is **auto-collected**: the server increments `char.potions` directly and notifies the client. If the character is already at the 10-potion cap, the roll is **wasted silently** (no drop event, no overflow, no replacement). This gives runs a sustain stream without committing potions to the bag/inventory pipeline.
 
+### Bag retention tiers
+On exit, the share of the bag the player can keep depends on which **combat phase** the exit was triggered in. Camps are the only path to 100% outside a boss kill:
+
+| Trigger | Phase | Bag retention |
+|---|---|---|
+| Boss kill | n/a | 100% (free pick) |
+| Camp (baked or via Incenso Etéreo) → Retornar | Acampamento | 100% (free pick) |
+| Retreat manual | Exploração | 30% (player picks which 30%) |
+| Retreat manual | Combate | 30% (player picks which 30%) |
+| Teleport Stone | mirrors phase above | 100% / 30% per phase |
+| Death | n/a | 0% (full wipe) |
+
+The **30% cap** (`floor(bag.length × 0.30)`, minimum 1 when bag has ≥1 item) is the punishment for unplanned exits: the player retains agency over *which* items survive, but loses the rest. The camp tier is the rewarded path — it's also the only spot where "Seguir em frente" preserves zone progress (any other exit ends the run).
+
 ### Inventory overflow and exit-modal flow
-On exit from a zone (Retreat / death-respawn does NOT count, that's a wipe), the **exit modal** appears with every staged item.
+On exit from a zone (Retreat / Teleport Stone / Camp Retornar — death-respawn does NOT count, that's a wipe), the **exit modal** appears with every staged item.
 
 - **Default state**: all items marked "keep".
 - **Player toggles** individual cards to mark "discard".
-- **"Get all"** button: marks every item as keep — disabled when total would exceed inventory free slots.
+- **"Get all"** button: marks every item as keep — disabled when total would exceed inventory free slots OR exceed the phase's bag cap (30% in exploração / combate).
+- **Phase cap enforcement**: in exploração or combate, the count of items marked "keep" is capped at `floor(bag.length × 0.30)` (minimum 1). Attempting to exceed it disables the toggle on additional items until something is unmarked.
 - **"Confirm"** with at least one item to discard: secondary warning "These items will be lost forever."
 - **"Confirm"** with zero items kept: warns "All items will be discarded."
 - **"Cancel"** closes the modal and returns the player to the engaged combat view — the zone bag persists, the session is unchanged.
@@ -243,7 +297,7 @@ Mobs use the same rarity ladder as items, with reduced reach:
 
 - **Normal mob** — baseline stats, no modifiers.
 - **Magic mob** — 1-2 modifiers rolled from the monster modifier pool. Slightly tougher than normal.
-- **Rare** — used exclusively for **minibosses** (the threshold spawn). Higher-tier modifier rolls. Drops better loot.
+- **Rare** — used exclusively for **minibosses** (the bar-fill spawn). Higher-tier modifier rolls. Drops better loot.
 - **Legendary / Epic mobs do not exist** — those tiers are reserved for items.
 
 ### Between-zone state
@@ -278,13 +332,24 @@ This naturally produces the PoE "self-sustaining gear" behaviour: a helmet that 
 **Visual signal** — broken items render with a red border (overriding the rarity color), a red `AlertTriangle` icon overlay, and a red warning line at the top of their tooltip: "Falta {N} de {Atributo}", one line per unmet requirement.
 
 ### Active player input
-Combat is otherwise automatic, but the player has **three active controls today**: using a **life potion**, using a **teleport stone**, and (out of combat) using a **wind crystal**.
+Combat is otherwise automatic, but the player has **three active controls today**: using a **life potion**, using a **teleport stone**, and using an **incenso etéreo**.
 
 - **Life Potion**: heals **20% of maximum HP**. Cap 10 carried. Obtained from the city vendor (10 rubys) or as a 20% monster drop (see Loot Pipeline → Potion drops). Potion button lives on the bottom-right of the combat view (next to the health globe) and on the map's status card.
-- **Teleport Stone**: instant return to the city, usable from any view (combat included — panic button). Wipes the active zone bag (you escape but abandon the loot). Uncapped (stockpile what you can afford). Vendor-only, 30 rubys. Button sits to the left of the potion in the combat HUD.
-- **Wind Crystal**: jumps the player to any previously-unlocked node with a fixed travel duration (no movement-speed scaling — you're skipping zones, not walking through them). Uncapped. Vendor-only, 50 rubys. Used from the map view only (clicking an unlocked-but-unconnected node opens a confirmation). Counter sits above the potion button in the combat HUD (display-only there; usage is map-only).
 
-The two travel consumables share the character document's `teleportStones` and `windCrystals` counters. The set of nodes available to wind crystals comes from `unlockedNodes` (see Travel system).
+- **Teleport Stone**: consumed to travel to any previously-visited node (entries in `unlockedNodes`). Single consolidated travel item — replaces the prior "stone-to-city + wind-crystal-to-other-nodes" split. Behavior:
+  - **City destination**: short travel time (3s) and grants the standard heal + potion refill on arrival.
+  - **Other nodes**: full travel time (~12s) and no heal — pure transport.
+  - Respects `isNodeAccessible` — locked nodes (upstream zone not completed) are rejected even if previously visited.
+  - **Bag retention follows the player's current phase** (see Loot Pipeline → Bag retention tiers): camp = 100%, exploração = 30%, combate = 30%. Stone is convenience: it skips the "retreat → map → consumable button" flow, lands the player at the chosen destination directly, and applies the heal/refill if that destination is the city.
+  - Lore: a "memory keeper" — it can only take the player to places whose echo it already carries.
+  - Uncapped. Vendor-only, 40 rubys.
+
+- **Incenso Etéreo**: consumable that triggers the camp cinematic at the player's chosen moment. Used during **exploração**, the next spawn doesn't occur and the modal opens with the same two options as a baked camp (Retornar com 100% / Seguir em frente). May be **activated during combate** and is then **queued** — it doesn't interrupt the current fight; immediately after the current enemy is resolved, the cinematic plays. Activation may also occur mid-ambush; the current mob completes, the remaining mobs in the ambush pack do NOT spawn, the cinematic takes over. **Does NOT activate during a boss fight** (boss = full commitment).
+  - Uncapped. **Drop only — never sold by vendors.** ~2-3% chance from any monster kill (independent roll, like potions). Lives on the character document as a counter (`char.etherealIncense: number`) until used.
+  - Cinematic uses the same structure as baked camps with different flavor text (e.g., "A fumaça arcana se dissipa pelos ares.", "O ar pesado e os sons perturbantes se reduzem à música do ambiente.").
+  - HUD button is the 4th active control in combat; greyed out during boss fight and while a camp cinematic is already active.
+
+The travel consumable is tracked on the character document as `teleportStones`. The wind crystal counter was retired in this consolidation; if any legacy data has it, treat as zero.
 
 Future skills will plug in as additional active controls; these three are the only ones in the MVP.
 
@@ -348,17 +413,16 @@ Legendaries are reachable in Act 1 from any source, but the baseline chance is *
 | Product | Price | Cap |
 |---|---|---|
 | Life Potion | 10 Rubys | 10 |
-| Teleport Stone | 30 Rubys | — |
-| Wind Crystal | 50 Rubys | — |
+| Teleport Stone | 40 Rubys | — |
 
-Potions are capped because they're the active heal control — supply matters for combat balance. Travel consumables are uncapped (player can stockpile arbitrarily many); their gameplay weight comes from the ruby cost, not from rationing.
+Potions are capped because they're the active heal control — supply matters for combat balance. Teleport Stone is uncapped (player can stockpile arbitrarily many); its gameplay weight comes from the ruby cost, not from rationing. **Incenso Etéreo is not sold** — it drops from monsters only (see Active player input → Incenso Etéreo).
 
 The catalog data lives in `src/game/vendor/products.ts`; adding a product means registering an id + price + emoji + (optionally) cap there. `convex/vendor.ts` → `vendorBuy` reads the metadata and walks one code path for all products.
 
 ### Selling rules
 
 - **Only inventory items can be sold.** Equipped gear must be unequipped first. This forces an intentional action before the player loses an item they were actually using.
-- **The vendor does not buy back consumables.** Potions (and future stones/crystals) are a one-way commitment once bought.
+- **The vendor does not buy back consumables.** Potions (and future stones) are a one-way commitment once bought.
 - **Sale is irrevocable.** The item is deleted from the items table and the character is credited Rubys atomically.
 
 ### Vendor price formula
@@ -445,7 +509,7 @@ The epithet is derived from the mods:
 Magic monsters keep the affix-based naming above ("Goblin Furioso da Velocidade"). Only rares get the proper-name treatment.
 
 ### Magic mob spawn rate
-10% of mid-zone spawns are magic; the rest are normal. The threshold spawn (miniboss) is always rare regardless.
+10% of mid-zone spawns are magic; the rest are normal. The bar-fill spawn (miniboss) is always rare regardless. Mobs that are part of an **ambush event** override the 10% baseline with the ambush's own magic rate (~60% per `pack.magicChance` — see Encounter Schedule).
 
 ---
 
@@ -503,7 +567,7 @@ time_seconds = max(0.5, distance / (1 + 2 × movementSpeed/100))
 The 2× coefficient on movement speed is intentional — boots can roll up to ~30% MS in early game and we want the player to *feel* that gear choice on the world map, not see a barely-perceptible improvement. The 0.5s floor keeps travel always visible.
 
 ### Unlocked nodes
-Every time the player arrives at a node (via any travel mechanic) the destination is appended to the character's `unlockedNodes` set. The character starts with `["city"]` on creation. This set is **append-only** — respawn doesn't clear it, leaving the world a one-time discover-then-fast-travel-back. Wind crystals consume the list to validate jump targets; nodes outside the list are inaccessible to crystals even if they're shown on the map.
+Every time the player arrives at a node (via any travel mechanic) the destination is appended to the character's `unlockedNodes` set. The character starts with `["city"]` on creation. This set is **append-only** — respawn doesn't clear it, leaving the world a one-time discover-then-fast-travel-back. Teleport stones consume this list to validate jump targets; nodes outside the list are inaccessible to stones even if they're shown on the map.
 
 ### Progression gating
 A connected combat node is **only travel-eligible if the player has completed the upstream zone**. Concretely:
@@ -511,9 +575,9 @@ A connected combat node is **only travel-eligible if the player has completed th
 - The graph imposes a partial order: the city's only outgoing edge is `forest_starter`, which is its own gate (no upstream); `forest_profunda` requires `forest_starter` complete; `pantano` requires `forest_profunda`; and so on through the linear chain.
 - City is always travel-eligible — it's the safety hub, no upstream gate.
 - Attempting to travel to a locked node surfaces a toast (`"Complete a zona anterior"`); the map's "you are here" pin stays put.
-- Wind crystals still respect this gate — jumping to a locked node is rejected (regardless of `unlockedNodes` membership).
+- Teleport stones still respect this gate — jumping to a locked node is rejected (regardless of `unlockedNodes` membership).
 
-A zone enters the **Complete** state by killing the miniboss at least once (see Zone states). The threshold counter for the current visit lives on the character document; the Complete set is persistent and per-character.
+A zone enters the **Complete** state by killing the miniboss at least once (see Zone states). The time-bar progress for the current visit lives on the character document; the Complete set is persistent and per-character.
 
 ### State on the character document
 Four fields capture the player's location on the act map:
@@ -525,9 +589,9 @@ Four fields capture the player's location on the act map:
 
 ### Behaviour rules
 - **Re-entering the same node is instant.** If the player retreats from a zone and clicks the same node again, no travel — they're already there.
-- **Disconnected nodes can't be travelled to directly** (today). Wind crystals will unlock that path later; for now, clicking an unconnected node surfaces a "no route" toast.
+- **Disconnected nodes can't be travelled to directly** by walking. Teleport stones unlock that path — clicking an unconnected node on the map opens a stone-confirmation if the node is in `unlockedNodes` and not zone-locked. Without a stone, the toast is "no route".
 - **Travel survives refresh.** `travelArrivesAt` lives in the DB. On reload the client recomputes remaining time and schedules `arriveAtTravel` accordingly. Tab closed for longer than the travel? The next load arrives immediately.
-- **No mid-travel actions.** Combat doesn't tick (the character isn't in any zone), `enterZone` rejects while travelling, and there's no cancel button. Future: teleport stones interrupt travel and snap to the city.
+- **No mid-travel actions.** Combat doesn't tick (the character isn't in any zone), `enterZone` rejects while travelling, and there's no cancel button. Future: teleport stones interrupt in-flight travel and re-target to the chosen destination.
 - **Death resets to the city** and clears any in-flight travel.
 
 ### UI

--- a/convex/itemValidator.ts
+++ b/convex/itemValidator.ts
@@ -119,4 +119,5 @@ export const generatedItemValidator = v.object({
 	computedStats: v.optional(computedWeaponStats),
 	computedDefenseStats: v.optional(computedDefenseStats),
 	requirements: v.optional(requirements),
+	icon: v.optional(v.string()),
 })

--- a/docs/plans/in-progress.md
+++ b/docs/plans/in-progress.md
@@ -6,6 +6,97 @@ When a planned item starts, move it to a feature branch and reference back here.
 
 ---
 
+## Time-based zone progression + Acampamento + Incenso Etéreo (active design)
+
+**Status**: Design locked, implementation pending.
+**Branch**: `feat/time-based-zones` (created from `origin/master`).
+
+### Why
+
+The current zone progression is a hidden 30-kill counter. The agreed redesign replaces it with a **time bar** that advances during exploração (gaps between encounters) and pauses during combate. The bar fills when the zone's encounter schedule completes, then the miniboss spawns. Goal: zone feels like a transit, not a kill quota.
+
+The design is fully documented in `CONTEXT.md` — see `### Time Bar`, `### Combat Phases`, `### Encounter Schedule`, `### Acampamento`, and `### Active player input` (Incenso Etéreo, consolidated Teleport Stone).
+
+### Scope summary
+
+- **Time Bar** (replaces Threshold Bar): per-zone encounter schedule + `spawn event` abstraction (`{ size: 1, kind, ... }`) to leave NvN combat as a future-portable extension.
+- **Encounter Schedule**: zone declares `encountersBeforeBoss`, `gapBetweenSpawns: {min, max}`, `ambushes: { count, packSize, gapWithinPack, magicChance }`, camp anchoring rules. Lives in `src/game/world/act-1.ts`.
+- **Acampamento** (camps): cinematic + modal with two options (Retornar com 100% / Seguir em frente). Baked into the schedule at anchored positions (~50% for `<20` encounters, ~33% + ~66% for `≥20`).
+- **Incenso Etéreo**: new consumable, drop-only (~2-3% from any kill), triggers the camp cinematic on demand. Queueable during combate; blocked during boss fight.
+- **Bag retention tiers**: camp = 100%, exploração = 30%, combate = 30%, morte = 0%. ExitZoneModal enforces 30% cap with player picking which slots.
+- **Teleport Stone consolidation**: stone absorbs the wind crystal's purpose. Single item, destination = any node in `unlockedNodes`. City gets short travel time (3s) + heal/refill; other nodes get the wind crystal's old travel time (~12s) + no heal. Vendor price 40r. `useWindCrystal` and the `windCrystals` counter are retired.
+
+### Required code changes (rough map)
+
+- `convex/combat.ts`:
+  - `recordKill` — drop `etherealIncense` independently on each kill (counter on character doc); decouple miniboss spawn from kill count (engine drives it from schedule end).
+  - `useTeleportStone` — accept `destinationNodeId: v.string()`; branch on `city` vs other (heal+refill only when city); compute `travelArrivesAt` from the appropriate constant.
+  - `useWindCrystal` — delete.
+  - Add `useEtherealIncense` mutation that triggers the camp cinematic flow (or model the cinematic purely client-side and just decrement the counter server-side).
+- `convex/schema.ts`: add `etherealIncense?: v.number()` to `characters`; consider retiring `windCrystals` (or leave for legacy data tolerance).
+- `src/game/world/act-1.ts`: each zone gets `encounterSchedule` data (encounter count, gap bounds, ambush spec, camp positions).
+- `src/game/combat/constants.ts`: add `STONE_TRAVEL_SECONDS_CITY` (3s), keep/rename `WIND_CRYSTAL_TRAVEL_SECONDS` → `STONE_TRAVEL_SECONDS_NON_CITY` (~12s).
+- `src/hooks/useCombatLoop.ts`: replace `KILLS_TO_THRESHOLD` flow with the schedule iterator; track current schedule slot; emit camp events at scheduled slots; queue incenso activations during combat.
+- New components: camp cinematic (`CampCinematic.tsx`?) with fade transitions and the two-option modal.
+- `src/components/world/ExitZoneModal.tsx`: enforce the 30% keep-cap when phase is exploração/combate (pass current phase from caller).
+- `src/components/world/StatusCard.tsx` / combat HUD: 4th button (Incenso Etéreo), greyed out per rules.
+- `src/game/vendor/products.ts`: drop wind crystal; update stone price.
+- `messages/pt.json` + `messages/en.json`: camp cinematic strings, incenso strings.
+
+### Validation
+
+```bash
+npx tsc --noEmit
+npx vitest run
+npx convex dev --once
+npx biome check src/ convex/
+```
+
+Manual smoke: enter zone, observe ambush event with magic pack, hit a baked camp (cinematic fires, modal opens with 2 options), use Continuar (bar resumes), reach miniboss, kill, see Zone Complete panel. Separately: drop an Incenso Etéreo, use mid-combat (queues), confirm cinematic fires after current kill. Separately: use Teleport Stone with non-city destination, confirm no heal/refill applied.
+
+### Open follow-ups (deferred in this PR — see entries below)
+
+- Act-boss node (Model B) re-fit for the time-bar system.
+- Biome-specific ambient audio for the camp cinematic.
+
+---
+
+## Act-boss node Model B refit for time-bar (deferred)
+
+**Status**: Planned, not started.
+**Triggered by**: time-based zone progression PR. The act-boss node still uses the older "Bar 1 fills → miniboss → Bar 2 fills → act boss" Model B (see CONTEXT.md → Act Boss). With regular zones moving to time-based bars, the act-boss node needs design alignment.
+
+### Open questions to resolve before coding
+
+- Does each Model B bar become a separate time-bar with its own schedule? Or stay as a kill counter (the act-boss node remains the only place with kill-counter pacing)?
+- Do camps appear in the act-boss node? Probably no — boss node = commitment.
+- Does the player get a checkpoint after killing the act-boss-miniboss (between Bar 1 and Bar 2)? With time-based, a brief pause + heal would feel natural — but it dilutes "Bar 2 starts immediately".
+- Does Incenso Etéreo work in the act-boss node? Probably no (mirroring the existing "no incenso during boss" rule applied to the whole boss node).
+
+### Why deferred
+
+Time-based zone progression is already large; mixing Model B redesign in would double the scope and complicate testing. Act-boss can ship on the old model until this lands.
+
+---
+
+## Camp cinematic biome-specific audio (deferred)
+
+**Status**: Planned, not started.
+**Triggered by**: time-based zone progression PR. The camp cinematic is text-only at first ship.
+
+### Why
+
+The cinematic was designed to include ambient sound cues per biome ("Sons da natureza calma..." in forest, frog/marsh sounds in pantano, etc.). The project already has hit-sound infrastructure to extend from. Text + fade alone delivers ~80% of the felt experience; audio is the last 20%.
+
+### Scope
+
+- Catalog biome ambient files (`/assets/audio/biomes/forest.mp3`, `pantano.mp3`, etc.).
+- Hook into the camp cinematic timeline: ambient fade-in synced with the first text fade-in; fade-out before the modal options appear.
+- Zone metadata declares its biome key; the cinematic looks up the matching audio.
+- Volume + accessibility: respect a future master volume setting.
+
+---
+
 ## Shared rarity-tinted card primitive (low priority refactor)
 
 **Status**: Planned, not started.

--- a/src/components/game/ItemCard.tsx
+++ b/src/components/game/ItemCard.tsx
@@ -63,9 +63,8 @@ type ItemIcon =
 	| { kind: "emoji"; char: string };
 
 function iconFor(item: GeneratedItem): ItemIcon {
-	// Item-local icon wins — used by hand-authored items (starter gear) whose
-	// templateId isn't in `TEMPLATE_BY_ID`. Falls back to the template's icon
-	// for normal rolled drops, then to per-type emoji.
+	// Hand-authored items (starter gear) carry their own icon since they have
+	// no template entry.
 	if (item.icon) return { kind: "sprite", src: item.icon };
 	const tpl = TEMPLATE_BY_ID.get(item.templateId);
 	if (tpl?.icon) return { kind: "sprite", src: tpl.icon };

--- a/src/components/game/ItemCard.tsx
+++ b/src/components/game/ItemCard.tsx
@@ -63,6 +63,10 @@ type ItemIcon =
 	| { kind: "emoji"; char: string };
 
 function iconFor(item: GeneratedItem): ItemIcon {
+	// Item-local icon wins — used by hand-authored items (starter gear) whose
+	// templateId isn't in `TEMPLATE_BY_ID`. Falls back to the template's icon
+	// for normal rolled drops, then to per-type emoji.
+	if (item.icon) return { kind: "sprite", src: item.icon };
 	const tpl = TEMPLATE_BY_ID.get(item.templateId);
 	if (tpl?.icon) return { kind: "sprite", src: tpl.icon };
 	if (item.weaponType && WEAPON_EMOJI_OVERRIDE[item.weaponType]) {

--- a/src/game/items/starter-gear.ts
+++ b/src/game/items/starter-gear.ts
@@ -6,12 +6,8 @@ import type { GeneratedItem } from "./types";
 // through the random generator. IDs are namespaced with the "starter:" prefix
 // so equipped-item references can distinguish them from rolled items later.
 
-// Starter weapons match the base stats of their T1 dropped counterparts
-// (Iron Sword / Iron Dagger / Apprentice Wand) but carry no implicit. The
-// upgrade incentive is the implicit (accuracy / crit multi / spell damage),
-// not raw weapon damage — that way a fresh character can sustain combat to
-// the first camp on starter gear, but still feels a clear power gain on the
-// first T1 drop.
+// Base stats mirror the T1 dropped equivalents; the upgrade incentive is the
+// implicit, not raw damage.
 
 const rustySword: GeneratedItem = {
 	id: "starter:rusty_sword",

--- a/src/game/items/starter-gear.ts
+++ b/src/game/items/starter-gear.ts
@@ -6,6 +6,13 @@ import type { GeneratedItem } from "./types";
 // through the random generator. IDs are namespaced with the "starter:" prefix
 // so equipped-item references can distinguish them from rolled items later.
 
+// Starter weapons match the base stats of their T1 dropped counterparts
+// (Iron Sword / Iron Dagger / Apprentice Wand) but carry no implicit. The
+// upgrade incentive is the implicit (accuracy / crit multi / spell damage),
+// not raw weapon damage — that way a fresh character can sustain combat to
+// the first camp on starter gear, but still feels a clear power gain on the
+// first T1 drop.
+
 const rustySword: GeneratedItem = {
 	id: "starter:rusty_sword",
 	templateId: "rusty_sword",
@@ -15,18 +22,19 @@ const rustySword: GeneratedItem = {
 	rarity: "normal",
 	name: "Rusty Sword",
 	itemLevel: 1,
+	icon: "/assets/sprites/armas/pesadas/espadaCurta.png",
 	baseStats: {
-		minDamage: 1,
-		maxDamage: 5,
-		attackSpeed: 1.0,
+		minDamage: 3,
+		maxDamage: 7,
+		attackSpeed: 1.5,
 		criticalChance: 5,
 	},
 	implicits: [],
 	explicits: [],
 	computedStats: {
-		physicalDamage: { min: 1, max: 5 },
+		physicalDamage: { min: 3, max: 7 },
 		elementalDamage: [],
-		attackSpeed: 1.0,
+		attackSpeed: 1.5,
 		criticalChance: 5,
 	},
 };
@@ -40,19 +48,22 @@ const rustyDagger: GeneratedItem = {
 	rarity: "normal",
 	name: "Rusty Dagger",
 	itemLevel: 1,
+	// No icon: daggers have no sprite assets in `public/assets/sprites/armas/`
+	// at the moment (gap also affects all dropped dagger tiers). Falls back to
+	// the emoji override. Add a sprite + populate this field when art lands.
 	baseStats: {
-		minDamage: 1,
-		maxDamage: 3,
-		attackSpeed: 1.6,
-		criticalChance: 8,
+		minDamage: 2,
+		maxDamage: 5,
+		attackSpeed: 1.7,
+		criticalChance: 6.5,
 	},
 	implicits: [],
 	explicits: [],
 	computedStats: {
-		physicalDamage: { min: 1, max: 3 },
+		physicalDamage: { min: 2, max: 5 },
 		elementalDamage: [],
-		attackSpeed: 1.6,
-		criticalChance: 8,
+		attackSpeed: 1.7,
+		criticalChance: 6.5,
 	},
 };
 
@@ -65,19 +76,20 @@ const crackedWand: GeneratedItem = {
 	rarity: "normal",
 	name: "Cracked Wand",
 	itemLevel: 1,
+	icon: "/assets/sprites/armas/caster/varinha.png",
 	baseStats: {
-		minDamage: 1,
-		maxDamage: 3,
+		minDamage: 2,
+		maxDamage: 6,
 		attackSpeed: 1.4,
-		criticalChance: 6,
+		criticalChance: 7,
 	},
 	implicits: [],
 	explicits: [],
 	computedStats: {
-		physicalDamage: { min: 1, max: 3 },
+		physicalDamage: { min: 2, max: 6 },
 		elementalDamage: [],
 		attackSpeed: 1.4,
-		criticalChance: 6,
+		criticalChance: 7,
 	},
 };
 

--- a/src/game/items/types/item.ts
+++ b/src/game/items/types/item.ts
@@ -91,4 +91,9 @@ export interface GeneratedItem {
 		dex?: number;
 		int?: number;
 	};
+	// Item-local sprite path. Takes precedence over the template's icon when
+	// rendering. Used for hand-authored items (starter gear) whose templateId
+	// isn't registered in `TEMPLATE_BY_ID`. Rolled drops normally leave this
+	// undefined and inherit the icon from their template.
+	icon?: string;
 }

--- a/src/game/items/types/item.ts
+++ b/src/game/items/types/item.ts
@@ -92,8 +92,6 @@ export interface GeneratedItem {
 		int?: number;
 	};
 	// Item-local sprite path. Takes precedence over the template's icon when
-	// rendering. Used for hand-authored items (starter gear) whose templateId
-	// isn't registered in `TEMPLATE_BY_ID`. Rolled drops normally leave this
-	// undefined and inherit the icon from their template.
+	// rendering — for hand-authored items (starter gear) without a template.
 	icon?: string;
 }

--- a/src/hooks/useCombatLoop.ts
+++ b/src/hooks/useCombatLoop.ts
@@ -584,28 +584,15 @@ export function useCombatLoop({
 		playerHpRef.current = optimisticHp;
 		setPlayerHp(optimisticHp);
 		setPotions(prevPotions - 1);
-		// `lastSyncedHpRef` tracks the *server's* known HP. After this potion
-		// the server knows HP at least went up by `heal`, but enemy damage
-		// during the roundtrip is unknown to the server — so for sync purposes
-		// we treat the optimistic value as the new server baseline. The next
-		// periodic sync flushes whatever the real local HP is by then.
 		lastSyncedHpRef.current = optimisticHp;
+		// HP stays at the optimistic value regardless of mutation outcome.
+		// The server's `result.hpCurrent` ignores combat damage that landed
+		// during the roundtrip, so writing it back would revert that damage
+		// (the up-down-up flicker). The periodic sync reconciles drift.
 		try {
 			const result = await consumePotion({ characterId });
-			// Trust the local optimistic HP. The server's `result.hpCurrent`
-			// is the heal applied to whatever HP the server last knew —
-			// which excludes any combat damage during the roundtrip. Writing
-			// it back would revert that damage and create a flicker
-			// (HP up → down → up as the damage tick gets clobbered then
-			// re-applied next swing). Only the potion count is server-truth.
 			setPotions(result.potions);
 		} catch {
-			// Mutation rejected (e.g., server-side "already at full HP" because
-			// the server's HP is stale from low sync frequency). Refund the
-			// potion count locally; leave HP at the optimistic value — combat
-			// damage may have already taken it down, and reverting to a
-			// `prevHp` snapshot would be wrong against that damage. The next
-			// periodic sync reconciles HP with the server.
 			setPotions(prevPotions);
 		}
 	}, [potions, playerHp, maxHp, characterId, consumePotion]);

--- a/src/hooks/useCombatLoop.ts
+++ b/src/hooks/useCombatLoop.ts
@@ -578,23 +578,34 @@ export function useCombatLoop({
 
 	const usePotion = useCallback(async () => {
 		if (potions <= 0 || playerHp >= maxHp) return;
-		const prevHp = playerHpRef.current;
 		const prevPotions = potions;
 		const heal = Math.floor(maxHp * POTION_HEAL_FRACTION);
-		const optimisticHp = Math.min(maxHp, prevHp + heal);
+		const optimisticHp = Math.min(maxHp, playerHpRef.current + heal);
 		playerHpRef.current = optimisticHp;
 		setPlayerHp(optimisticHp);
 		setPotions(prevPotions - 1);
+		// `lastSyncedHpRef` tracks the *server's* known HP. After this potion
+		// the server knows HP at least went up by `heal`, but enemy damage
+		// during the roundtrip is unknown to the server — so for sync purposes
+		// we treat the optimistic value as the new server baseline. The next
+		// periodic sync flushes whatever the real local HP is by then.
 		lastSyncedHpRef.current = optimisticHp;
 		try {
 			const result = await consumePotion({ characterId });
-			playerHpRef.current = result.hpCurrent;
-			setPlayerHp(result.hpCurrent);
+			// Trust the local optimistic HP. The server's `result.hpCurrent`
+			// is the heal applied to whatever HP the server last knew —
+			// which excludes any combat damage during the roundtrip. Writing
+			// it back would revert that damage and create a flicker
+			// (HP up → down → up as the damage tick gets clobbered then
+			// re-applied next swing). Only the potion count is server-truth.
 			setPotions(result.potions);
-			lastSyncedHpRef.current = result.hpCurrent;
 		} catch {
-			playerHpRef.current = prevHp;
-			setPlayerHp(prevHp);
+			// Mutation rejected (e.g., server-side "already at full HP" because
+			// the server's HP is stale from low sync frequency). Refund the
+			// potion count locally; leave HP at the optimistic value — combat
+			// damage may have already taken it down, and reverting to a
+			// `prevHp` snapshot would be wrong against that damage. The next
+			// periodic sync reconciles HP with the server.
 			setPotions(prevPotions);
 		}
 	}, [potions, playerHp, maxHp, characterId, consumePotion]);

--- a/src/hooks/useCombatLoop.ts
+++ b/src/hooks/useCombatLoop.ts
@@ -579,21 +579,29 @@ export function useCombatLoop({
 	const usePotion = useCallback(async () => {
 		if (potions <= 0 || playerHp >= maxHp) return;
 		const prevPotions = potions;
+		const prevHp = playerHpRef.current;
 		const heal = Math.floor(maxHp * POTION_HEAL_FRACTION);
-		const optimisticHp = Math.min(maxHp, playerHpRef.current + heal);
+		const optimisticHp = Math.min(maxHp, prevHp + heal);
+		const appliedHeal = optimisticHp - prevHp;
 		playerHpRef.current = optimisticHp;
 		setPlayerHp(optimisticHp);
 		setPotions(prevPotions - 1);
 		lastSyncedHpRef.current = optimisticHp;
-		// HP stays at the optimistic value regardless of mutation outcome.
-		// The server's `result.hpCurrent` ignores combat damage that landed
-		// during the roundtrip, so writing it back would revert that damage
-		// (the up-down-up flicker). The periodic sync reconciles drift.
+		// On success, keep the local optimistic HP — the server's `hpCurrent`
+		// ignores combat damage that landed during the roundtrip, so writing
+		// it back would revert that damage (the up-down-up flicker).
+		// On failure, subtract only the heal delta we applied; any damage taken
+		// during the roundtrip stays. Forces a re-sync so the server's truth
+		// flows back on the next tick instead of waiting for the 10s interval.
 		try {
 			const result = await consumePotion({ characterId });
 			setPotions(result.potions);
 		} catch {
+			const reverted = Math.max(0, playerHpRef.current - appliedHeal);
+			playerHpRef.current = reverted;
+			setPlayerHp(reverted);
 			setPotions(prevPotions);
+			lastSyncedHpRef.current = -1;
 		}
 	}, [potions, playerHp, maxHp, characterId, consumePotion]);
 


### PR DESCRIPTION
## Summary

Mixed PR with two concerns — feel free to ask for a split if you'd rather review separately.

**Early-game polish (3 commits, ship-ready):**
- `fix:` Potion no longer flickers HP up→down→up. Server response to consumePotion was clobbering local optimistic HP + any combat damage taken during the roundtrip.
- `feat:` `icon?: string` on `GeneratedItem`. Lets hand-authored items (starter gear) carry their own sprite. Drops are unaffected.
- `balance:` Starter weapons (Rusty Sword / Dagger / Cracked Wand) buffed to match T1 base stats minus the implicit. A fresh character now sustains combat to the first camp position of forest_starter.

**Time-based zone design (1 commit, docs only):**
- `docs:` Crystallizes the agreed design from a grilling session into `CONTEXT.md` (Time Bar, Combat Phases, Encounter Schedule, Acampamento, Bag retention tiers, Incenso Etéreo, stone consolidation that absorbs wind crystal) and adds the implementation map + two deferred follow-ups to `docs/plans/in-progress.md`.
- **Implementation is NOT in this PR.** This is design crystallization ahead of the code changes that the next PR(s) will land.

## Notes

- Daggers have no sprite in any tier today (gap also affects all dropped daggers, not just starter). Flagged for art work.
- Stone repriced 30r → 40r in vendor catalog (docs only — code change comes with the consolidation PR).
- Old branch `feat/new-travel-item-tooltip-desc-and-progression` (empty, never merged) being cleaned up alongside this PR.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 298/298 pass
- [x] Manual: level-1 combat feel verified by user — potion no longer flickers, starter weapons sustain to first encounters

🤖 Generated with [Claude Code](https://claude.com/claude-code)