### PR TITLE
docs: refresh playbooks + codebase map for post-lexicon shape

### DIFF
--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -42,13 +42,14 @@ No React. No Convex. Same code runs on client and server (convex imports from he
 |---|---|---|
 | `classes/` | Character class definitions (Warrior/Rogue/Mage) | `data.ts` (CLASS_DEFINITIONS), `types.ts` |
 | `combat/` | Damage/defense math, constants | `damage.ts`, `barrier.ts`, `leech.ts`, `constants.ts` |
+| `i18n/` | Naming-lexicon primitives shared by all locales | `lexicon-shared.ts` (`GrammaticalGender`, `GenderedForm`, `pickGendered`) |
 | `inventory/` | Inventory constants + helpers | `constants.ts` (INVENTORY_MAX_SLOTS, bySlotAsc) |
-| `items/` | Item generator, modifier data, equip helpers | See below — the biggest subdir |
+| `items/` | Item generator, modifier data, equip helpers, lexicon | See below — the biggest subdir |
 | `loot/` | Drop tables | `drops.ts` (rollDrop, rollMonsterLevel) |
 | `monsters/` | Monster definitions | `data.ts`, `types.ts` |
 | `progression/` | XP curves, death penalty | `levels.ts` (xpToNextLevel, applyXpGain, applyDeathXpPenalty) |
 | `stats/` | The stat engine | `compute.ts` (computeCharacterStats), `types.ts` (EquippedSlot, narrowEquippedSlot, ComputedCharacterStats) |
-| `world/` | Acts, zones, node graph, zone-name i18n | `act-1.ts`, `index.ts`, `types.ts`, `i18n.ts` |
+| `world/` | Acts, zones, node graph, zone-name i18n, monster-name lexicon | `act-1.ts`, `index.ts`, `types.ts`, `i18n.ts`, `lexicon/{en,pt,types}.ts` |
 
 ### `src/game/items/` — item subsystem detail
 
@@ -59,11 +60,14 @@ items/
 ├── equipment.ts             # planEquip, validSlotsForItem, isTwoHanded, weaponArchetype — shared client+server
 ├── equipment.test.ts        # planEquip rules (2H displacement, archetype, etc.)
 ├── starter-gear.ts          # Hand-crafted starter weapons (rusty_sword, rusty_dagger, cracked_wand)
-├── mod-i18n.ts              # PT formatters for explicit mods + implicit pattern-match
+├── item-name.ts             # translateItemName / translateTemplateName — display-time renderer (locale × rarity, UUID-seeded rare names)
+├── item-name.test.ts        # 20 tests: gender concord, UUID determinism, locale switch, fallback
+├── mod-i18n.ts              # PT formatters for explicit mods + implicit pattern-match (tooltip mod lines)
 ├── MODIFIER_GUIDELINES.md   # Notes on individual modifier semantics (crit, leech)
 ├── data/
 │   ├── modifiers/           # One file per category — defines the modifier pool
 │   │   ├── index.ts         # Aggregates everything into MODIFIERS + ModifierId type
+│   │   ├── affix-ids.ts     # PrefixModifierId / SuffixModifierId literal unions (lexicon coverage)
 │   │   ├── weapon-damage.ts # Local attack mods
 │   │   ├── spell-damage.ts  # Flat spell damage (staff/wand only)
 │   │   ├── global-damage.ts # Global %, attack/cast speed, global crit
@@ -71,18 +75,37 @@ items/
 │   │   ├── resistances.ts
 │   │   ├── attributes.ts
 │   │   ├── utility.ts       # Movement speed, leech, stun, reduced reqs
+│   │   ├── tome.ts          # Tome-exclusive gain-as-extra elemental
 │   │   └── magic-find.ts
 │   └── templates/           # Equipment base templates, one file per slot/weapon type
 │       ├── swords.ts, daggers.ts, axes.ts, ...  (one per weapon type)
 │       ├── helmets.ts, chestplates.ts, boots.ts, gloves.ts
-│       ├── shields.ts
+│       ├── shields.ts, tomes.ts, quivers.ts
 │       └── rings.ts, amulets.ts, belts.ts
+├── lexicon/                 # Per-locale item naming data (composed by item-name.ts)
+│   ├── template-ids.ts      # TemplateBaseId + TemplateModifierId literal unions
+│   ├── types.ts             # ItemNameLexicon contract (bases, modifiers, prefix/suffix, rare pools)
+│   ├── en.ts                # English lexicon
+│   └── pt.ts                # Portuguese lexicon (gendered)
 └── types/
     ├── base.ts              # EquipmentType, WeaponType, ArmorType, BaseStatKey, EQUIPMENT_GROUPS
     ├── mods.ts              # Modifier, RolledMod, StatEffect, ModifierTier
     ├── item.ts              # GeneratedItem (the thing stored in the items table)
     └── index.ts
 ```
+
+### `src/game/items/lexicon/` — naming data
+
+Item display names compose at render time from `(nameBase, nameModifier)` tuples on each template. Two locales today (en, pt) sharing a single contract in `types.ts`. Adding a new locale = one new file under this directory.
+
+| File | Role |
+|---|---|
+| `template-ids.ts` | Literal-union sources of truth: `TemplateBaseId` (~55 bases) and `TemplateModifierId` (~80 modifiers). Templates and lexicons reference these unions — missing entries fail at compile. |
+| `types.ts` | `ItemNameLexicon` interface. `bases` keyed by `TemplateBaseId`, `modifiers` keyed by `TemplateModifierId`, `prefixForms`/`suffixPhrases` keyed by `PrefixModifierId`/`SuffixModifierId`. |
+| `en.ts` | English entries. Bases as `{ name: string }`. Modifiers as flat strings. |
+| `pt.ts` | Portuguese entries. Bases as `{ name, gender: "m" \| "f" }`. Modifiers as `string` (invariant phrase) or `{ m, f }` (gendered adjective). |
+
+See `docs/playbooks/i18n-which-system.md` for the broader decision tree (paraglide vs lexicon vs `mod-i18n.ts`).
 
 ### `src/game/stats/compute.ts` — the stat engine
 
@@ -201,4 +224,6 @@ Convex imports from `src/game/*` use **relative paths** (`../src/game/...`), not
 | "What does the stat engine actually do?" | `src/game/stats/compute.ts` + tests in `compute.test.ts` |
 | "How does dual-wield work?" | `CONTEXT.md` → Dual-wielding |
 | "Why doesn't this Convex error look like English?" | `src/lib/convex-errors.ts:translateServerError` |
-| "How are items shown in the tooltip translated?" | `src/game/items/mod-i18n.ts` |
+| "How are item tooltip mod lines translated?" | `src/game/items/mod-i18n.ts` |
+| "How are item names rendered (per locale)?" | `src/game/items/item-name.ts` + `lexicon/{en,pt}.ts` |
+| "Which i18n system should I use for new strings?" | `docs/playbooks/i18n-which-system.md` |

--- a/docs/plans/in-progress.md
+++ b/docs/plans/in-progress.md
@@ -97,59 +97,69 @@ The cinematic was designed to include ambient sound cues per biome ("Sons da nat
 
 ---
 
-## Item tooltip i18n + item name lexicon (NEXT)
+## Item naming lexicon — open follow-ups (low priority)
 
-**Status**: PR1 in progress on branch `feat/tooltip-i18n`. PR2 not started. Mirrors the pattern from `feat/per-locale-monster-name-renderer` (commit `e304c76`) — same render-at-display + per-locale lexicon shape that monsters already use.
+**Status**: PRs #39 (tooltip labels + slot-aware mods) and #41 (decomposed lexicon + renderer + 20 tests) landed. The four items below are real but were intentionally deferred — none blocks a beta, but each one closes a small hole that will widen as more locales / modifiers land.
 
-**Why**: today the item tooltip mixes localized mod descriptions (PT via `mod-i18n.ts`) with hardcoded English labels (Physical Damage, Armour, Item Level, Requires) and English item names baked at generation time. Three concrete bugs:
+### 1. Cross-coverage test: lexicon affix forms ↔ `mod-i18n.ts`
 
-1. Static labels in `src/components/game/ItemTooltip.tsx` ignore the active locale entirely.
-2. PT formatter for `localDefenseFlat`/`localDefenseIncrease` always renders "Defesa", ignoring the item's `armorType` — so a leather glove with +20 evasion shows "+20 de Defesa" instead of "+20 de Evasão". In EN the same path resolves correctly because `resolveDefenseFormat` (`generator.ts:176`) bakes the right word into `mod.description` at roll time; the PT formatter is keyed by `modifierId` and never sees `armorType`.
-3. Item names (`item.name`) are frozen as English strings at generation. Switching to PT does nothing — same shape as the bug the monster-naming PR fixed for enemies. Bonus: commit `4436da0` silently reverted the PT jewelry rename from `ee15ce2` — having names inline in templates is fragile.
+**Risk**: The same `ModifierId` universe is translated in two independent tables — `lexicon.prefixForms` / `suffixPhrases` (magic-item compound name) and `mod-i18n.ts:PT_EXPLICIT_FORMATTERS` (tooltip mod line). Different data, but a new modifier needs entries in both. Today nothing forces that — a missing entry on either side renders the modifier id as a string fallback.
 
-### PR1: Tooltip labels + slot-aware mod renderer (this branch)
+**Fix** (estimated: ~10 lines of test). One vitest file that iterates `MODIFIERS` and, per locale, asserts every prefix has a `lexicon.prefixForms` entry AND every modifier has a `PT_EXPLICIT_FORMATTERS` entry (or its EN equivalent path). Catches drift at CI time instead of at the tooltip.
 
-**Branch**: `feat/tooltip-i18n` (based on origin/master).
+**Why deferred**: low rate of new modifiers — the pool is mature, drift is unlikely in the next month. Worth adding before the next big modifier expansion.
 
-- Replace hardcoded labels in `ItemTooltip.tsx` with `m.*` calls. Reuse existing keys (`stats_armor`, `element_cold`, `attribute_strength`) where shape matches; add new keys for tooltip-specific contexts (e.g. `tooltip_attacks_per_second` separate from `stats_attack_speed`, since the former is a rate stat and the latter is the `% increased` mod label).
-- Refactor `localizeMod(mod)` → `localizeMod(mod, item)`. PT formatter for `localDefenseFlat`/`localDefenseIncrease` reads `item.armorType` and picks `Armadura`/`Evasão`/`Barreira` from a small lookup table.
-- **Migrate both locales to render-at-display-time**. EN stops trusting `mod.description` and re-renders from `modifierId + value + item` the same way PT does. The slot-aware resolver (`resolveDefenseFormat`) gets duplicated/moved into the display layer. `mod.description` stays on the stored shape (legacy data) but is no longer consumed by the tooltip.
-- `(Local)` keeps the same string in both locales (chave nova `m.mod_local_suffix()`).
-- No schema migration.
+### 2. Native PT-BR review of bulk-translated entries
 
-**Validation**:
-- `npx tsc --noEmit`, `npx vitest run`
-- Manual: drop a plate helmet with `+X local defense` → "+X de Armadura" / "+X Armour". Same mod on a leather glove → "+X de Evasão" / "+X Evasion Rating". Same on a silk chest → "+X de Barreira" / "+X Barrier". Toggle language in Settings — every tooltip string flips locale without touching the items.
+**Risk**: 130-ish lexicon entries (55 bases + 80 modifiers) were AI-bulk-translated. The four manually reviewed (Espada Bastarda, Estrela da Manhã, Maculado pelo Vazio, Gume) caught real awkwardness, so the rest probably has 5–10 similar issues. Fine for indie / pre-release. Not fine before a paid release in Brazil.
 
-### PR2: Item name lexicon refactor
+**Fix**: Walk through `lexicon/pt.ts` with a native speaker, especially:
 
-**Branch**: suggested `feat/item-name-lexicon`, based on PR1.
+- All `gendered` adj forms — check the `m`/`f` inflection
+- The 21-tier "owner" ladder (warden / champion / templar / archon / sovereign / etc.) reads as a power progression — does the PT chain feel like ascending power?
+- Tier-21 void specials — the new `void_touched` / `void_forged` / `void_woven` / `void_inscribed` family is intentional, but each adjective should feel epic in PT.
 
-Mirrors `src/game/world/lexicon/`. New directory `src/game/items/lexicon/{en,pt}.ts`.
+**Why deferred**: project is solo dev pre-release. Translation quality is the kind of thing a real audience surfaces, not a code reviewer.
 
-- **EN lexicon shape**: `{ TEMPLATE_NAMES: Record<templateId, string>, PREFIX: Record<modId, string>, SUFFIX: Record<modId, string>, NAME_FIRST: string[], NAME_SECOND: string[] }`.
-- **PT lexicon shape**: `{ TEMPLATE_NAMES: Record<templateId, { name: string, gender: "m" | "f" }>, PREFIX: Record<modId, { m: string, f: string }>, SUFFIX: Record<modId, string>, PRIMEIRO: string[], SEGUNDO: string[] }`. Suffix string carries its own `da`/`do`/`das` particle; `SEGUNDO[]` carries its connector too (e.g. `"da Tempestade"`, `"do Vazio"`).
-- **Renderer**: single `translateItemName(item)` in `src/game/items/item-name.ts` (or similar). Dispatch on `getLocale()`, then on `item.rarity`:
-  - Normal: `templateName`.
-  - Magic: PT composes `${templateName} ${prefix-gendered} ${suffix}` ("Espada de Ferro Pesada da Rapidez"); EN composes `${prefix} ${templateName} ${suffix}` ("Heavy Iron Sword of Swiftness"). Prefix picks the gender form per `TEMPLATE_NAMES_PT[templateId].gender`.
-  - Rare/Legendary/Epic: `${pool1[idx0]} ${pool2[idx1]}` where `idx0 = floor(hash(item.id, 0) * pool1.length)` and same for `idx1`. Result: "Lâmina da Tempestade" / "Doom Mark". **No `nameSeed` stored** — derived deterministically from `item.id` (UUID), so a single item renders the same proper name forever, and legacy items get a name without migration.
-- **Delete `name` from templates** (`data/templates/*.ts`) — language-neutral. Adding a new locale = one new lexicon file.
-- **Delete `name` from modifier definitions** (`data/modifiers/*.ts`). `RolledMod.modifierName` becomes `v.optional()` in the items validator (legacy items still parse; new items can omit it).
-- **Delete `buildItemName` from `generator.ts`** — naming migrates entirely to the display layer.
-- `item.name` on `GeneratedItem` becomes optional/legacy; new items don't populate it (or populate with `translateItemName(item, "en")` for log-friendly debugging — TBD when implementing).
-- Lexicon EN + PT shipped together — no bilingual interim. Estimate: ~200 template entries × 2 locales, ~50 modifier prefix/suffix entries × 2 locales, two 30-word pools × 2 locales. Mechanical, reviewable line-by-line.
+### 3. Codegen for `TemplateBaseId` / `TemplateModifierId`
 
-**Validation**:
-- `npx tsc --noEmit`, `npx vitest run`
-- Manual: each rarity (normal, magic, rare, legendary, epic) for at least one weapon, one armor, one jewelry, one offhand. Toggle locale — same item, name flips PT↔EN. Same rare item across sessions/page reloads — name stays the same (seed comes from UUID).
-- Spot-check gender agreement: same prefix on a feminine template ("Espada Pesada") and a masculine template ("Elmo Pesado").
+**Risk**: `src/game/items/lexicon/template-ids.ts` declares the two literal unions by hand. The data files (`data/templates/*.ts`) reference these unions but the union itself is human-maintained — if someone adds a base/modifier to a template file using a string that isn't yet in the union, TypeScript catches it. But adding the union member doesn't force them to add a lexicon entry until they re-run tsc.
 
-### Risks / conflicts
+**Fix**: small codegen step. Walk `data/templates/*.ts` at build time (or via a `vitest` snapshot), collect every `nameBase` / `nameModifier` value, emit `template-ids.generated.ts`. The hand-written file just re-exports the generated union. Lexicons then can't compile if the unions grow without entries.
 
-- **Shared with planned "rarity-tinted card primitive" refactor** (entry below): both touch `ItemTooltip.tsx`. Land the i18n PRs first — they're higher signal — then the card primitive can refactor structure without worrying about the label set.
-- **`mod.description` becomes legacy** after PR1. Anywhere else in the codebase that reads it (admin panel, debug logs, tests) needs to either re-render via `localizeMod` or accept stale strings on legacy items.
-- **No schema migration** for PR2 because the seed is derived from UUID — but the items validator still needs to accept items WITHOUT `modifierName`/`name` (make those `v.optional()`).
-- **Shared file with parallel combat feature**: `messages/{pt,en}.json`. PR1 inserts new keys grouped near existing `stats_*` (mid-file) to avoid line-adjacency merge conflicts with feature work appending at the end.
+**Why deferred**: the hand-maintained file works for now. Codegen is the right call if/when there's a sustained pace of adding new bases.
+
+### 4. Hash function → `src/lib/rng.ts`
+
+**Risk**: `hashItemId` in `item-name.ts` is FNV-1a; `CombatScene.tsx` has a separate `*31`-walk hash. Both are deterministic string→[0, 1) hashes. Two implementations, same purpose, will drift.
+
+**Fix**: extract to `src/lib/rng.ts` as `hashStringToUnit(s, salt?)` (or two-output variant). Both callers consume from there. Was flagged in the first simplify pass and deferred — the second caller (CombatScene) uses a weaker hash that probably should upgrade to match.
+
+**Why deferred**: not load-bearing, both implementations currently work. Worth doing when next touching `CombatScene`'s hash.
+
+### 5. Convex validator can't enforce literal unions
+
+**Constraint, not a bug**. `nameBase` / `nameModifier` are stored as `v.optional(v.string())` because Convex validators don't have ergonomic literal-union support. The in-process `GeneratedItem` type widens to `string` at the persistence boundary — the lexicon files themselves keep the union enforcement. If Convex ever ships a `v.unionLiteral([...])` helper, swap in.
+
+---
+
+## Split `src/routes/world.tsx` (queued)
+
+**Status**: Planned, not started. User has requested this be picked up after the in-flight time-based-zones work wraps.
+
+**Why**: `src/routes/world.tsx` is **836 lines** today. It's the orchestrator route — combat hook, all eight-or-so modals, twelve+ mutations with optimistic closures, the view-mode state machine (map / city / combat), the priority text log. The agent who needs to add a new button in the HUD or wire a new mutation has to read the whole thing before they're confident they won't break adjacent logic.
+
+### Suggested cut
+
+- **`useWorldMutations`** custom hook — extracts the `useMutation(...).withOptimisticUpdate(...)` declarations into one place. Each declaration is 10-40 lines today; pulling them out drops world.tsx by ~250 lines and makes the optimistic recipes easier to compare.
+- **`useViewMode`** custom hook — encapsulates the `viewMode: "map" | "city" | "combat"` state machine + the auto-transitions on `enterZone` / `enterCity` / `exitZone` arrival.
+- **Modal manager** — the 8+ `useModal()` calls + state for which item / loot bag / vendor product the modal targets could collapse into one `useWorldModals()` hook returning a stable typed API. Or extract each modal block into a sibling component that owns its own visibility.
+- **Combat HUD section** — the JSX for the bottom-of-screen combat buttons (potion, teleport stone, retreat, loot preview) is its own thing — pull into `<CombatHud character={...} />`.
+
+### Validation
+
+- `npx tsc --noEmit`, `npx vitest run` (no UI test coverage today; rely on TS + manual smoke).
+- Manual smoke: enter zone → kill mob → exit with loot picker → equip new item → travel to next zone. The five main user-flows touch every part of world.tsx.
 
 ---
 

--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -11,7 +11,8 @@ Use these when the task matches an existing pattern. For one-off architectural c
 - [Adding a monster](./adding-a-monster.md) — new mob template + zone hookup
 - [Adding a zone](./adding-a-zone.md) — new combat/city node in an act
 - [Adding a class](./adding-a-class.md) — new playable class
-- [Adding an i18n key](./adding-an-i18n-key.md) — new user-facing string
+- [Adding an i18n key](./adding-an-i18n-key.md) — new user-facing string (paraglide)
+- [Which i18n system to use](./i18n-which-system.md) — decision tree: paraglide vs lexicon vs `mod-i18n.ts`
 - [Touching combat](./touching-combat.md) — read this before editing `useCombatLoop.ts`
 
 ## Conventions

--- a/docs/playbooks/adding-a-modifier.md
+++ b/docs/playbooks/adding-a-modifier.md
@@ -1,6 +1,6 @@
 # Adding a modifier
 
-A "modifier" is a rolled affix on a generated item — e.g. "+15 Strength", "+20% Increased Fire Damage". Adding one touches 3-4 files in predictable spots.
+A "modifier" is a rolled affix on a generated item — e.g. "+15 Strength", "+20% Increased Fire Damage". Adding one touches 4-5 files in predictable spots. Two of those are i18n tables that must stay in sync — TypeScript catches missing entries via literal-union Records.
 
 ## Decide first
 
@@ -24,16 +24,14 @@ Open the right file under `src/game/items/data/modifiers/`:
 - Str/Dex/Int → `attributes.ts`
 - Movement speed, leech, stun, on-kill, reduced reqs → `utility.ts`
 - Item Rarity (Magic Find) → `magic-find.ts`
+- Tome-exclusive gain-as-extra → `tome.ts`
 
-Add an entry. The example below is a complete, copy-pasteable `increased`
-prefix; swap `Increase` for `Flat` (and `modifierType: "flat"`) for an
-additive mod, or `Suffix Name` + `affixType: "suffix"` for a suffix.
+Add an entry. The example below is a complete, copy-pasteable `increased` prefix; swap `Increase` for `Flat` (and `modifierType: "flat"`) for an additive mod, or `affixType: "suffix"` for a suffix.
 
 ```ts
 myNewStatIncrease: {
-    id: "myNewStatIncrease",           // id must end in Flat / Increase / More
-    name: "Prefix Name",                // shown in the magic-item generated name
-    affixType: "prefix",                // or "suffix" — flips name to "of Suffix Name"
+    id: "myNewStatIncrease",            // id must end in Flat / Increase / More
+    affixType: "prefix",                // or "suffix"
     modifierType: "increased",          // or "flat" — must match the id's suffix
     category: "offensive",              // offensive | defensive | attribute | utility
     applicableTo: ["allArmor", "ring"], // groups + specific slots, see EQUIPMENT_GROUPS
@@ -44,21 +42,36 @@ myNewStatIncrease: {
 },
 ```
 
-Local mods (the ones that mutate a weapon's `computedStats`) need a
-`statEffect` declaration instead of `isGlobalStat: true`. See CLAUDE.md
-"statEffect" for the target/operation table.
+**No `name` field**. The magic-item compound name pulls from `lexicon.prefixForms` / `lexicon.suffixPhrases` (step 4 below) so EN/PT can have different forms with gender concord.
+
+Local mods (the ones that mutate a weapon's `computedStats`) need a `statEffect` declaration instead of `isGlobalStat: true`. See CLAUDE.md "statEffect" for the target/operation table.
 
 The modifier id ends in `Flat` / `Increase` / `More` — the suffix and `modifierType` must agree. See `CONTEXT.md` → Modifier ID Naming Convention.
 
 **The generator will pick it up automatically** via the `MODIFIERS` spread in `src/game/items/data/modifiers/index.ts`. No registration needed.
 
-## Step 2 — Teach the stat engine to consume it (global mods only)
+## Step 2 — Add the id to the affix-type union
+
+Open `src/game/items/data/modifiers/affix-ids.ts` and add your id to either `PrefixModifierId` or `SuffixModifierId` (matching its `affixType`).
+
+```ts
+export type PrefixModifierId = Extract<
+    ModifierId,
+    | "localDefenseFlat"
+    // …existing…
+    | "myNewStatIncrease"               // add here
+>;
+```
+
+This is what forces the lexicon to cover your mod — step 4 won't compile until you add the entry.
+
+## Step 3 — Teach the stat engine to consume it (global mods only)
 
 If it's a global mod (`isGlobalStat: true`), add a case in the `applyMod()` switch in `src/game/stats/compute.ts`:
 
 ```ts
-case "myNewMod":
-    stats.someField += v;
+case "myNewStatIncrease":
+    stats.increased.someField += v;
     return;
 ```
 
@@ -68,33 +81,78 @@ If the mod affects damage calculations, also wire it through `rollPlayerSwing` i
 
 **Local mods skip this step** — `statEffect` already tells the generator how to bake the value into the weapon's `computedStats`. Verify it's reflected in `src/game/items/generator.ts:computeWeaponStats` if you added a new `LocalStatTarget`.
 
-## Step 3 — Add Portuguese localization
+## Step 4 — Add affix translations to both locales
 
-Open `src/game/items/mod-i18n.ts` and add an entry to `PT_EXPLICIT_FORMATTERS`:
+The magic-item compound name (e.g. "Heavy Iron Sword") needs an entry per locale. Open both lexicon files:
+
+**`src/game/items/lexicon/en.ts`** — `prefixForms` or `suffixPhrases`:
 
 ```ts
-myNewMod: (v) => `+${v} de Coisa`,
+prefixForms: {
+    // …existing…
+    myNewStatIncrease: "Mighty",        // EN doesn't inflect
+},
 ```
 
-The format must match the meaning of `displayFormat` from step 1. If your mod can appear as an **implicit** on a template, add a regex pattern to `PT_IMPLICIT_PATTERNS` too.
+**`src/game/items/lexicon/pt.ts`** — same key:
 
-## Step 4 — Verify
+```ts
+prefixForms: {
+    // …existing…
+    myNewStatIncrease: { m: "Poderoso", f: "Poderosa" },
+    // or just "do Poder" if the modifier is an invariant phrase, not an adjective
+},
+```
+
+If TS errors at the lexicon Record — that means step 2 worked. Add the entry, error clears.
+
+For **suffixes**, `suffixPhrases` takes a single string (no gender concord — suffixes anchor to their own noun: "da Rapidez" already carries "Rapidez"'s feminine "da"). Example: `"da Força"`.
+
+## Step 5 — Add the tooltip-line translation
+
+This is the OTHER i18n table. It controls how the mod renders inside the item tooltip — separate from the magic-name affix.
+
+Open `src/game/items/mod-i18n.ts` and add to `PT_EXPLICIT_FORMATTERS`:
+
+```ts
+myNewStatIncrease: (m) => `+${m.value}% de Coisa`,
+```
+
+The format must mirror the `displayFormat` from step 1 semantically. EN renders automatically by interpolating `displayFormat` — no entry needed there.
+
+If your mod can appear as an **implicit** on a template (uncommon — implicits come from templates, not affix rolls), add a regex pattern to `PT_IMPLICIT_PATTERNS` matching the literal EN displayFormat.
+
+## Step 6 — Verify
 
 ```bash
 npx tsc --noEmit
 npx vitest run src/game/items/generator.test.ts
 npx vitest run src/game/stats/compute.test.ts
+npx vitest run src/game/items/item-name.test.ts
 ```
 
-Generator tests will catch:
+Tests will catch:
 - "no decimals in rolled values"
 - "prefix/suffix limits per rarity"
-- "Magic items don't exceed 2 mods"
-
-Stat engine tests will catch missing `applyMod` case (the universal `globalDamageIncrease` was once removed for exactly this reason — see commit history).
+- "magic items compose with the right affix order"
+- Stat engine: missing `applyMod` case
+- Item naming: gender concord on adjective modifiers
 
 If the mod is balance-sensitive (premium weight, exclusive slot), drop in a `weight: N` comment explaining the rationale — future agents won't know.
 
-## Step 5 — Test the drop visually
+## Step 7 — Test the drop visually
 
-Run `npm run dev`, create or load a character, retreat from a zone with items in the bag, open the loot picker. Verify the new mod shows on dropped items with the right localized text.
+Run `npm run dev`, create or load a character, retreat from a zone with items in the bag, open the loot picker. Verify:
+
+1. The mod shows on dropped items with the right localized line in the tooltip body (step 5)
+2. Magic items that roll this mod get the right compound name in both locales (step 4) — e.g. "Mighty Iron Sword" / "Espada de Ferro Poderosa"
+3. Toggle PT↔EN via Settings — both renderings flip cleanly
+
+## Reminder: why two i18n entries per modifier
+
+There are two unrelated displays of the same modifier:
+
+- **Magic item compound name** (`lexicon.prefixForms` / `suffixPhrases`) — "Heavy Iron Sword". One word, anchored to a noun, needs gender concord in PT.
+- **Tooltip mod line** (`mod-i18n.ts:PT_EXPLICIT_FORMATTERS`) — "+15 Physical Damage to Attacks". Full sentence with the rolled value interpolated.
+
+Both keyed by the same `modifierId`. Forgetting one renders the affix as a raw id string in that surface. See `docs/playbooks/i18n-which-system.md` for the broader i18n decision tree.

--- a/docs/playbooks/adding-an-equipment-template.md
+++ b/docs/playbooks/adding-an-equipment-template.md
@@ -2,13 +2,16 @@
 
 A "template" is a base item — a tier of sword, a base of helmet. Templates carry baseline stats (damage range, attack speed for weapons; defense value for armor), level + attribute requirements, and any implicits (free stats that always roll on this base).
 
+Names are **not** stored on the template itself — they're composed at display time from a `(nameBase, nameModifier)` tuple by the lexicon system. See `src/game/items/lexicon/`.
+
 ## Decide first
 
-1. **What slot?** Weapon (which type — sword/dagger/staff/etc), helmet, chestplate, boots, gloves, ring, amulet, belt, offhand (shield).
-2. **What tier slot in the ladder?** Templates ladder by ilvl gating. Pick the next sequential id (`rusty_sword`, `iron_sword`, `steel_sword`, ...).
-3. **For armor: what base type?** plate / leather / silk — determines whether `localDefenseFlat` resolves to armor / evasion / barrier (see `CONTEXT.md` → Armor Bases).
+1. **What slot?** Weapon (which type — sword/dagger/staff/etc), helmet, chestplate, boots, gloves, ring, amulet, belt, offhand (shield), tome, quiver.
+2. **What tier slot in the ladder?** Templates ladder by `dropLevel`. Pick the next sequential id (`sword_t1`, `sword_t2`, …).
+3. **For armor: what base type?** `plate` / `leather` / `silk` — determines whether `localDefenseFlat` resolves to armor / evasion / barrier (see `CONTEXT.md` → Armor Bases).
 4. **Requirements?** Level + str/dex/int. Look at neighboring templates for the same type to keep the curve consistent.
 5. **Implicits?** Most don't have any. Jewelry (rings, amulets) often does — usually a resistance or attribute roll. See `src/game/items/data/templates/rings.ts` for examples.
+6. **What name?** Decide the `(nameBase, nameModifier)` tuple. **Both must already exist** in `src/game/items/lexicon/template-ids.ts`. If you need a new base noun or modifier, see "Step 4 — Adding a new base or modifier" below.
 
 ## Step 1 — Add the template
 
@@ -30,6 +33,8 @@ Open the right file under `src/game/items/data/templates/`. One file per categor
 | boots | `boots.ts` |
 | gloves | `gloves.ts` |
 | shield | `shields.ts` |
+| tome | `tomes.ts` |
+| quiver | `quivers.ts` |
 | ring | `rings.ts` |
 | amulet | `amulets.ts` |
 | belt | `belts.ts` |
@@ -38,29 +43,42 @@ Add an entry to the exported array:
 
 ```ts
 {
-    id: "iron_sword",                  // unique across all templates
-    name: "Iron Sword",
+    id: "sword_t5",                     // unique across all templates
+    nameBase: "sword",                  // TemplateBaseId — must exist in lexicon
+    nameModifier: "war",                // TemplateModifierId | null — must exist in lexicon if non-null
     equipmentType: "weapon",
-    weaponType: "sword",               // weapons only
-    armorType: "plate",                // armor only
-    minItemLevel: 8,                   // first ilvl this can drop at
-    maxItemLevel: 12,                  // last ilvl this can drop at
+    weaponType: "sword",                // weapons only
+    armorType: "plate",                 // armor only
+    dropLevel: 14,                      // ilvl at which this can first drop
     baseStats: {
-        minDamage: 5,
-        maxDamage: 10,
-        attackSpeed: 1.4,
-        criticalChance: 6,             // weapons only — armor uses { armor, evasion, barrier }
+        minDamage: 14,
+        maxDamage: 32,
+        attackSpeed: 1.5,
+        criticalChance: 5,              // weapons only — armor uses { armor, evasion, barrier }
     },
-    requirements: { level: 8, str: 16, dex: 16 },
-    implicits: [],                     // or [{ displayFormat: "+{value}% Cold Resistance", minValue: 15, maxValue: 25 }]
+    requirements: { level: 14, str: 28, dex: 28 },
+    implicits: [
+        {
+            modifierId: "accuracyFlat",
+            displayFormat: "+{value} Accuracy Rating",
+            minValue: 130,
+            maxValue: 180,
+        },
+    ],
 },
 ```
 
+`nameBase` and `nameModifier` are checked against the literal unions in `src/game/items/lexicon/template-ids.ts`. A typo or unknown id fails at compile time — you don't need to memorize them, just try and let TS guide you.
+
 The generator picks templates from `src/game/items/data/templates/index.ts` — the spread is automatic, no registration needed.
 
-## Step 2 — Verify ilvl bands
+### Programmatic templates (tome / quiver)
 
-Templates of the same type form a ladder. Check that `minItemLevel`/`maxItemLevel` bands don't overlap with siblings or leave gaps — the generator picks the matching template per drop ilvl, and an unmatched ilvl crashes the roll.
+`tomes.ts` and `quivers.ts` build their `EquipmentTemplate[]` by `.map()`-ing over a `TomeTierSpec[]` / `QuiverTierSpec[]`. The `nameModifier` for each tier is pulled from a `TOME_MODIFIERS` / `QUIVER_MODIFIERS` array. If you add a new tier, append to **both** the spec array and the modifier array (TS will tell you if the lengths drift).
+
+## Step 2 — Verify the dropLevel ladder
+
+Templates of the same type form a ladder. Check that `dropLevel` is sequential with siblings — the loot roller picks all templates with `dropLevel <= itemLevel`, so a gap doesn't crash, but a tier that's much weaker than its sibling at the same drop level dilutes the rare-quality pool.
 
 Quick sanity check:
 
@@ -68,7 +86,7 @@ Quick sanity check:
 npx vitest run src/game/items/generator.test.ts
 ```
 
-The generator tests roll thousands of items and would catch a gap.
+The generator tests roll thousands of items and would catch a wiring break.
 
 ## Step 3 — Implicit i18n (if you added one)
 
@@ -76,14 +94,28 @@ If your template has implicits with English `displayFormat` strings, check `src/
 
 ```ts
 {
-    test: /^\+\d+ Maximum Mana$/i,
+    test: /^\+\d+ to Maximum Mana$/i,
     render: (v) => `+${v} de Mana Máxima`,
 },
 ```
 
-Implicits don't have modifier ids — the matcher works on the literal English string.
+Implicits don't have modifier ids on `RolledImplicit` — the matcher works on the literal English string. New patterns are easy to miss; if you ship without one, the implicit renders in English in PT mode.
 
-## Step 4 — Verify
+## Step 4 — Adding a new base or modifier (if needed)
+
+If your template needs a `nameBase` or `nameModifier` that doesn't exist yet:
+
+1. Add the id (snake_case) to the appropriate union in `src/game/items/lexicon/template-ids.ts`.
+2. Add a `bases` entry to **both** `src/game/items/lexicon/en.ts` and `src/game/items/lexicon/pt.ts`. PT entries set `gender: "m" | "f"`.
+3. Add a `modifiers` entry to both. PT can be a plain string (invariant phrase like `"de Ferro"`) or `{ m, f }` for adjectives that inflect with the base.
+4. TS will tell you if you forgot any of the three (the lexicon Records require literal-union coverage).
+
+Naming guide:
+- Materials → snake_case noun (`iron`, `copper`, `bronze`, `oak`, `silk`)
+- Possessives → snake without apostrophe (`soldiers`, `knights`, `hunters`)
+- Adjectives that inflect → snake_case adjective (`hallowed`, `runed`, `void_touched`)
+
+## Step 5 — Verify
 
 ```bash
 npx tsc --noEmit
@@ -91,14 +123,18 @@ npx vitest run
 npx biome check src/
 ```
 
-Open the admin items panel if you have admin role (`/admin/items`) and roll a few drops at your template's ilvl band to eyeball the result.
+Open the admin items panel if you have admin role (`/admin/items`) and roll a few drops at your template's `dropLevel` to eyeball the display name in both EN and PT (toggle via Settings).
 
-## Gotcha: requirement curves
+## Gotchas
 
+### Requirement curves
 Look at the existing curve before picking your numbers. For example:
 
-- Swords requirement curve: STR + DEX both, starting (10, 10) at level 1, scaling to (~112, 112) at level 80
-- Axes: STR only, (15) at level 1, (~140) at level 80
-- Wands: INT only, (10) at level 1, (~138) at level 80
+- Swords: STR + DEX both, starting (10, 10) at level 1, scaling to (~112, 112) at level 80
+- Axes: STR only, starting (15), scaling to (~140) at level 80
+- Wands: INT only, starting (10), scaling to (~138) at level 80
 
-A new tier 5 sword should sit between tier 4 and tier 6 cleanly — about (25, 25) STR/DEX. Don't make up numbers; interpolate from siblings.
+A new tier-5 sword should sit between tier-4 and tier-6 cleanly — about (28, 28) STR/DEX. Don't make up numbers; interpolate from siblings.
+
+### Display name fallback
+If `nameBase` or `nameModifier` resolves to a lexicon entry that doesn't exist (shouldn't happen with the literal unions, but possible via casts), the renderer falls back to the `templateId` string. If you see a raw `sword_t5` in the tooltip during testing, that's the signal — fix the lexicon entry.

--- a/docs/playbooks/i18n-which-system.md
+++ b/docs/playbooks/i18n-which-system.md
@@ -1,0 +1,103 @@
+# Which i18n system do I use?
+
+The game has **three** translation systems running in parallel. Each exists for a reason — picking the wrong one breaks runtime fallback paths or makes future locales painful. This doc is the decision tree.
+
+## Decision tree
+
+**Q1: Is the string a UI label that doesn't change per-item / per-monster?**
+(Button text, panel header, error message, settings option, modal title, etc.)
+
+→ **Paraglide messages** — `messages/{en,pt}.json` + call as `m.key_name()`.
+
+**Q2: Is the string a noun phrase whose translation depends on grammatical gender or context (per item, per monster)?**
+(Item names like "Espada Sagrada" / "Espada Sagrado", monster names with adjective concord.)
+
+→ **Lexicon** — `src/game/items/lexicon/{en,pt}.ts` (items) or `src/game/world/lexicon/{en,pt}.ts` (monsters).
+
+**Q3: Is the string a stat description that interpolates a rolled numeric value, and might have different word order in PT vs EN?**
+(Mod tooltip lines like "+15 Physical Damage to Attacks" / "+15 de Dano Físico em Ataques".)
+
+→ **mod-i18n.ts** — `src/game/items/mod-i18n.ts:PT_EXPLICIT_FORMATTERS`.
+
+## When each system applies
+
+### Paraglide (`messages/{en,pt}.json` + `import { m } from "#/paraglide/messages"`)
+
+**Use for**: static UI strings — every button label, every panel header, every error, every modal title. Anything that the player sees in the chrome around the game, not in the game data itself.
+
+**Conventions**:
+- Keys are snake_case, namespaced by surface (`stats_*`, `tooltip_*`, `vendor_*`, `loot_*`).
+- Parameterized via `{name}` placeholders, called as `m.foo({ name: "x" })`.
+- Both `en.json` and `pt.json` MUST have every key — paraglide errors at compile.
+- Adding a new key: see `docs/playbooks/adding-an-i18n-key.md`.
+
+**Don't use for**:
+- Per-item names (the player sees thousands of these — paraglide isn't built for game data with grammatical concerns)
+- Tooltip mod lines (those need runtime value interpolation with min-max range support; paraglide can't reach in)
+
+### Lexicon (`src/game/items/lexicon/`, `src/game/world/lexicon/`)
+
+**Use for**: noun phrases whose translation depends on **grammatical gender** or **adjective concord** in PT. Item base names + magic-item affix forms; monster names + monster modifier adjectives.
+
+**Why it exists**: paraglide treats every string as opaque. If you want "Iron Sword" → "Espada de Ferro" (PT material phrase appended) and the same modifier "Hallowed" to render as "Sagrada" on a sword (feminine) but "Sagrado" on a helmet (masculine), you need a lookup table that carries gender alongside the noun. Paraglide can't model that without exploding into key-suffix soup.
+
+**Conventions**:
+- One file per locale: `lexicon/en.ts`, `lexicon/pt.ts`. Both `export` an object matching the `ItemNameLexicon` (or `MonsterNameLexicon`) interface.
+- The interface uses `Record<TemplateBaseId, ...>` etc. — literal-union keys. Forgetting a key in either locale is a compile error.
+- PT entries carry `gender: "m" | "f"` on bases; modifiers that inflect are `{ m, f }` GenderedForm objects.
+- Composition logic lives in the renderer (`item-name.ts`, `world/i18n.ts`), NOT in the lexicon data.
+
+**Don't use for**:
+- UI labels (use paraglide — lexicons aren't meant to be exhaustive for chrome)
+- Tooltip mod lines (use mod-i18n — different concern: value interpolation + word order)
+
+### `mod-i18n.ts` (`src/game/items/mod-i18n.ts`)
+
+**Use for**: the rendered text of a rolled item mod inside the tooltip body. Things like `"+15 Physical Damage to Attacks"` (EN) / `"+15 de Dano Físico em Ataques"` (PT). Each mod has its own format that interpolates the rolled value.
+
+**Why it exists**:
+- EN renders by interpolating the mod's `displayFormat` (`"+{value} Physical Damage to Attacks"`) at display time — automatic, no per-mod EN entry needed.
+- PT word order, gender concord, and idioms don't map cleanly from the EN format. So PT has a per-modifierId formatter table (`PT_EXPLICIT_FORMATTERS`) where each entry returns the rendered string.
+- The renderer also passes the `item` so slot-aware modifiers (local defense) can pick the right noun (Armadura / Evasão / Barreira).
+
+**Conventions**:
+- Keyed by `modifierId`. EN derives from `MODIFIERS[id].displayFormat`; PT uses the formatter table.
+- A new modifier needs an entry in `PT_EXPLICIT_FORMATTERS` to render in PT (otherwise falls back to the EN displayFormat).
+- For implicits (whose displayFormat lives on the template, not on `MODIFIERS`), `PT_IMPLICIT_PATTERNS` does regex-based translation.
+
+**Don't use for**:
+- Item base names or magic-item affix words (use lexicon — different concern: noun phrases with concord)
+- UI labels (use paraglide)
+
+## "Where do I put it" cheatsheet
+
+| Surface | System |
+|---|---|
+| Settings panel labels | Paraglide |
+| Error toast messages | Paraglide |
+| Stat panel section titles | Paraglide |
+| Status card numeric labels ("Vida", "Mana") | Paraglide |
+| Item name in tooltip header ("Espada de Ferro") | Lexicon |
+| Monster name in combat header | Lexicon (world) |
+| Magic-item compound name affix ("Sagrada" prefix) | Lexicon |
+| Tooltip mod line ("+15 de Dano Físico em Ataques") | mod-i18n |
+| Tooltip implicit line ("+50 Vida") | mod-i18n PT_IMPLICIT_PATTERNS |
+| Damage popup numbers | Paraglide (the label, e.g. "Crítico!") |
+| Zone name on the map ("Floresta Profunda") | Paraglide |
+
+## Cross-system rules
+
+- **One modifier = TWO i18n entries** (lexicon affix form + mod-i18n tooltip line). They translate the same modifier but for different displays. Adding a new mod without both is fine TypeScript-wise (the lexicon Records are `Partial<Record<...>>`) but produces the modifier id as a string fallback in whichever surface lacks the entry.
+- **A new template = ONE possible new lexicon entry pair** (base + modifier, if they don't already exist in `template-ids.ts`). See `adding-an-equipment-template.md` step 4.
+- **A new monster = ONE lexicon entry** in the monster lexicon. See `adding-a-monster.md`.
+- **A new UI string = ONE paraglide entry** in both `messages/en.json` AND `messages/pt.json`. See `adding-an-i18n-key.md`.
+
+## Why three systems instead of one
+
+Tried in PR #41 and rejected:
+
+- **Just use paraglide for everything**: gender concord turns into `prefix_hallowed_m` / `prefix_hallowed_f` key explosions. Paraglide's parameter system doesn't model "pick masc/fem based on a separate runtime value". Possible with conditionals but messy at scale.
+- **Just use a single lexicon with all UI strings inside**: lexicons run through the renderer, which means every UI label would need a render step. Paraglide's static-extract-at-build-time pipeline is faster and supports tooling (lint for missing keys, future translation platforms).
+- **Just use mod-i18n.ts for everything mod-related**: doesn't handle compound naming because tooltip mod lines and magic-item affix names are different shapes. Forcing one table to do both creates per-entry conditional logic.
+
+The split mirrors three different problems with three different solutions. The cost is the discipline to know which to use — hence this doc.


### PR DESCRIPTION
## Summary

Pure docs. The item-i18n refactor (PRs #39 + #41) shipped without bringing the playbooks along, so an agent following them today would write broken code.

- **\`adding-an-equipment-template.md\`** rewritten for the new shape: \`nameBase\` / \`nameModifier\` decomposition, \`dropLevel\` ladder (was \`minItemLevel\`/\`maxItemLevel\`), Step 4 for adding a new base or modifier to the lexicon, Step 5 note about programmatic templates (tome / quiver) using a tier-indexed modifier array.
- **\`adding-a-modifier.md\`** rewritten to cover the dual i18n path: Step 2 registers the id in \`affix-ids.ts\` (so the lexicon Record refuses to compile without coverage); Step 4 adds the lexicon affix translation (both locales); Step 5 adds the tooltip-line translation. Closing reminder explains why two i18n entries per modifier and links to the new decision-tree doc.
- **New: \`i18n-which-system.md\`** — decision tree for paraglide (UI labels) vs lexicon (noun phrases with concord) vs \`mod-i18n.ts\` (tooltip mod lines with value interpolation). Includes a where-do-I-put-it cheatsheet and a section on why we have three systems instead of one.
- **\`codebase-map.md\`** picks up \`src/game/i18n/lexicon-shared.ts\` and the full \`src/game/items/lexicon/\` tree.
- **\`in-progress.md\`** retires the shipped item-i18n entries, adds the five open follow-ups from the PR #41 senior review (cross-coverage test, native PT review, template-id codegen, hash extraction, validator-literal limitation), and parks a stub for the queued \`src/routes/world.tsx\` split.

## Test plan

- [x] No code changed
- [ ] Skim the new playbooks one more time before merge — flag any leftover stale reference

🤖 Generated with [Claude Code](https://claude.com/claude-code)