### PR TITLE
feat(convex): server-authoritative camp/phase derivation

### DIFF
--- a/convex/_shared/character.ts
+++ b/convex/_shared/character.ts
@@ -95,6 +95,7 @@ export function clearPerVisitZoneState() {
 		zoneStartedAt: undefined,
 		campThresholdsMs: undefined,
 		inCamp: false,
+		lastCampIndex: undefined,
 	} as const
 }
 

--- a/convex/_shared/character.ts
+++ b/convex/_shared/character.ts
@@ -84,6 +84,20 @@ export function newZoneSession(): string {
 	return `${Date.now().toString(36)}-${Math.random().toString(36).slice(2, 10)}`
 }
 
+// Patch fields that scope to a single zone visit — session id, time-bar
+// origin, server-rolled camp thresholds, and the camp phase flag. Spread
+// into `ctx.db.patch` whenever a visit ends (exitZone, useTeleportStone,
+// respawnDead) so a new visit always starts from a clean slate without
+// any one site forgetting a field.
+export function clearPerVisitZoneState() {
+	return {
+		currentZoneSession: undefined,
+		zoneStartedAt: undefined,
+		campThresholdsMs: undefined,
+		inCamp: false,
+	} as const
+}
+
 // Append `item` to `list` if it's not already present. Returns the same
 // reference when no change is needed so callers can `if (next === list)
 // skip update`. Used for `unlockedNodes` and similar append-only sets

--- a/convex/combat.ts
+++ b/convex/combat.ts
@@ -122,8 +122,29 @@ export const recordKill = mutation({
 			// inCamp flag so exitZone/pickFromBag derive the camp phase
 			// during the post-miniboss modal pause.
 			updates.inCamp = true
+			// Per CONTEXT.md → Zone Miniboss: continuing past the panel resets
+			// the bar to 0 and rerolls the schedule. The client's calmaria
+			// ticker resets locally; the server must mirror that by rerolling
+			// thresholds and resetting `zoneStartedAt` so the next loop's
+			// enterCamp time-gate isn't trivially satisfied by stale wall-clock
+			// elapsed from the previous loop. lastCampIndex resets so the new
+			// loop can claim camp[0] again.
+			const zone = findNode(ACT_1, currentLocation)
+			if (zone && zone.kind === "combat") {
+				const plan = zone.encounterPlan ?? DEFAULT_ENCOUNTER_PLAN
+				updates.campThresholdsMs = rollCampThresholdsMs(plan)
+				updates.zoneStartedAt = Date.now()
+				updates.lastCampIndex = undefined
+			}
 		} else {
 			updates.currentZoneKills = currentZoneKills + 1
+			// Defense-in-depth: a miniboss kill flips `inCamp = true` and
+			// expects the client to call `exitCamp` via dismissMinibossModal
+			// before resuming normal combat. If a client skips the dismiss and
+			// keeps farming, leaving `inCamp` set would grant 100% retention
+			// to subsequent bag commits. Clearing it on every non-miniboss
+			// kill closes that gap without changing the legitimate flow.
+			updates.inCamp = false
 		}
 
 		// Potion drop — independent of the equipment roll. At the 10-potion cap
@@ -409,12 +430,15 @@ export const enterZone = mutation({
 		const encounterPlan = zone.encounterPlan ?? DEFAULT_ENCOUNTER_PLAN
 		const campThresholdsMs = rollCampThresholdsMs(encounterPlan)
 		const zoneStartedAt = Date.now()
+		// Spread the helper first so every per-visit field (including future
+		// additions like `lastCampIndex`) gets a clean slate; the explicit
+		// writes below then set this visit's session/timestamp/thresholds.
 		await ctx.db.patch(args.characterId, {
+			...clearPerVisitZoneState(),
 			currentZoneSession: zoneSession,
 			currentZoneKills: 0,
 			zoneStartedAt,
 			campThresholdsMs,
-			inCamp: false,
 		})
 		return { zoneSession, zoneStartedAt, campThresholdsMs }
 	},
@@ -453,13 +477,28 @@ export const enterCamp = mutation({
 		// instead of throwing — the player is already where they want to be.
 		if (char.inCamp) return { inCamp: true }
 
+		// Strictly-increasing index: each camp threshold is single-use per visit.
+		// Without this, a player could enter camp[0], exit, then re-call
+		// enterCamp(0) any time later — the elapsed-time gate still passes
+		// because time only moves forward, so inCamp would flip back to true
+		// and grant another 100% retention exit.
+		if (
+			char.lastCampIndex !== undefined &&
+			args.thresholdIndex <= char.lastCampIndex
+		) {
+			throw new ConvexError("Camp threshold already consumed")
+		}
+
 		const threshold = thresholds[args.thresholdIndex]
 		const elapsed = Date.now() - zoneStartedAt
 		if (elapsed < threshold - ENTER_CAMP_GRACE_MS) {
 			throw new ConvexError("Camp threshold not reached")
 		}
 
-		await ctx.db.patch(args.characterId, { inCamp: true })
+		await ctx.db.patch(args.characterId, {
+			inCamp: true,
+			lastCampIndex: args.thresholdIndex,
+		})
 		return { inCamp: true }
 	},
 })

--- a/convex/combat.ts
+++ b/convex/combat.ts
@@ -33,6 +33,10 @@ import { rollDrop, rollMinibossDrops } from "../src/game/loot/drops"
 import { findMonster } from "../src/game/monsters/data"
 import { scaleMonsterStats } from "../src/game/monsters/scaling"
 import {
+	DEFAULT_ENCOUNTER_PLAN,
+	rollCampThresholdsMs,
+} from "../src/game/world/encounter-schedule"
+import {
 	applyDeathXpPenalty,
 	applyOverlevelPenalty,
 	applyXpGain,
@@ -112,6 +116,11 @@ export const recordKill = mutation({
 			if (!completed.includes(currentLocation)) {
 				updates.completedZones = [...completed, currentLocation]
 			}
+			// Miniboss-victory is a 100% bag-retention tier (see
+			// derivePhase in src/game/combat/types.ts). Flip the server-side
+			// inCamp flag so exitZone/pickFromBag derive the camp phase
+			// during the post-miniboss modal pause.
+			updates.inCamp = true
 		} else {
 			updates.currentZoneKills = currentZoneKills + 1
 		}
@@ -220,10 +229,36 @@ export const useEtherealIncense = mutation({
 		const count = char.etherealIncense ?? 0
 		if (count <= 0) throw new ConvexError("No incense to use")
 
+		// `inCamp` is NOT flipped here. Incense may be queued during "engaged"
+		// (the cinematic only fires after the current fight finishes), so the
+		// client calls `enterCampViaIncense` separately when the cinematic
+		// actually begins. The counter still decrements on use so a kill
+		// landing between use+enter can't race the consume.
 		await ctx.db.patch(args.characterId, {
 			etherealIncense: count - 1,
 		})
 		return { etherealIncense: count - 1 }
+	},
+})
+
+// Camp entry triggered by Incenso Etéreo. Bypasses the time-threshold gate
+// since incense is a player-driven "summon a camp" affordance — the gate
+// is the consumed counter (charged in useEtherealIncense). Sets inCamp =
+// true. Idempotent. Distinct from `enterCamp` so the time-gated path can't
+// be widened by accident. See docs/plans/in-progress.md
+// "Server-authoritative camp/phase derivation".
+export const enterCampViaIncense = mutation({
+	args: { characterId: v.id("characters") },
+	handler: async (ctx, args) => {
+		const authUser = await authComponent.getAuthUser(ctx)
+		if (!authUser) throw new ConvexError("Not authenticated")
+		const char = await loadOwnedCharacter(ctx, authUser._id, args.characterId)
+
+		if (char.zoneStartedAt === undefined)
+			throw new ConvexError("Not in a zone")
+
+		await ctx.db.patch(args.characterId, { inCamp: true })
+		return { inCamp: true }
 	},
 })
 
@@ -320,6 +355,11 @@ export const respawnDead = mutation({
 			potions: refilledPotions,
 			currentZoneSession: undefined,
 			currentZoneKills: 0,
+			// Server-authoritative camp/phase state is per-visit; clear it on
+			// death so the next enterZone rolls a fresh schedule.
+			zoneStartedAt: undefined,
+			campThresholdsMs: undefined,
+			inCamp: false,
 			// Respawn resets you to the city and clears any in-flight travel.
 			currentLocation: "city",
 			travelDestination: undefined,
@@ -364,11 +404,82 @@ export const enterZone = mutation({
 		// Threshold counter resets on every entry — per CONTEXT.md: "fill resets
 		// to 0 every time the player leaves the zone with the miniboss unsummoned".
 		// Boss Deferral isn't implemented yet, so the counter resets unconditionally.
+		//
+		// Server-authoritative camp scheduling: roll the camp thresholds here so
+		// a tampered client can't fabricate an early `enterCamp` claim. Falls back
+		// to DEFAULT_ENCOUNTER_PLAN for safety, though every combat node in act-1
+		// declares its own plan today. See docs/plans/in-progress.md
+		// "Server-authoritative camp/phase derivation".
+		const encounterPlan = zone.encounterPlan ?? DEFAULT_ENCOUNTER_PLAN
+		const campThresholdsMs = rollCampThresholdsMs(encounterPlan)
+		const zoneStartedAt = Date.now()
 		await ctx.db.patch(args.characterId, {
 			currentZoneSession: zoneSession,
 			currentZoneKills: 0,
+			zoneStartedAt,
+			campThresholdsMs,
+			inCamp: false,
 		})
-		return { zoneSession }
+		return { zoneSession, zoneStartedAt, campThresholdsMs }
+	},
+})
+
+// Camp entry — gated server-side by the elapsed-time threshold rolled at
+// enterZone. Closes Threat #3 (client-trusted phase). The 500ms grace window
+// absorbs clock drift between the client's calmaria ticker and the server's
+// wall clock so a legitimate camp trigger isn't rejected for being a frame
+// too early. See docs/plans/in-progress.md "Server-authoritative camp/phase
+// derivation".
+const ENTER_CAMP_GRACE_MS = 500
+
+export const enterCamp = mutation({
+	args: {
+		characterId: v.id("characters"),
+		thresholdIndex: v.number(),
+	},
+	handler: async (ctx, args) => {
+		const authUser = await authComponent.getAuthUser(ctx)
+		if (!authUser) throw new ConvexError("Not authenticated")
+		const char = await loadOwnedCharacter(ctx, authUser._id, args.characterId)
+
+		const zoneStartedAt = char.zoneStartedAt
+		if (zoneStartedAt === undefined) throw new ConvexError("Not in a zone")
+
+		const thresholds = char.campThresholdsMs ?? []
+		if (
+			args.thresholdIndex < 0 ||
+			args.thresholdIndex >= thresholds.length
+		)
+			throw new ConvexError("Invalid camp threshold")
+
+		// Idempotent on the same index: if a network retry or double-fire from the
+		// client lands a second enterCamp while we're already in camp, swallow it
+		// instead of throwing — the player is already where they want to be.
+		if (char.inCamp) return { inCamp: true }
+
+		const threshold = thresholds[args.thresholdIndex]
+		const elapsed = Date.now() - zoneStartedAt
+		if (elapsed < threshold - ENTER_CAMP_GRACE_MS) {
+			throw new ConvexError("Camp threshold not reached")
+		}
+
+		await ctx.db.patch(args.characterId, { inCamp: true })
+		return { inCamp: true }
+	},
+})
+
+// Camp exit — clears the inCamp flag. Called when the player picks "Seguir
+// em frente" on the camp panel. No time gate; the cinematic is purely a
+// player-driven dismiss.
+export const exitCamp = mutation({
+	args: { characterId: v.id("characters") },
+	handler: async (ctx, args) => {
+		const authUser = await authComponent.getAuthUser(ctx)
+		if (!authUser) throw new ConvexError("Not authenticated")
+		await loadOwnedCharacter(ctx, authUser._id, args.characterId)
+
+		await ctx.db.patch(args.characterId, { inCamp: false })
+		return { inCamp: false }
 	},
 })
 
@@ -553,6 +664,9 @@ export const useTeleportStone = mutation({
 				hpCurrent: stats.maxLife,
 				potions: refilledPotions,
 				currentZoneSession: undefined,
+				zoneStartedAt: undefined,
+				campThresholdsMs: undefined,
+				inCamp: false,
 				travelDestination: "city",
 				travelStartedAt: startedAt,
 				travelArrivesAt: arrivesAt,
@@ -563,6 +677,9 @@ export const useTeleportStone = mutation({
 		await ctx.db.patch(args.characterId, {
 			teleportStones: stones - 1,
 			currentZoneSession: undefined,
+			zoneStartedAt: undefined,
+			campThresholdsMs: undefined,
+			inCamp: false,
 			travelDestination: destinationNodeId,
 			travelStartedAt: startedAt,
 			travelArrivesAt: arrivesAt,

--- a/convex/combat.ts
+++ b/convex/combat.ts
@@ -46,6 +46,7 @@ import { ACT_1, findNode, isNodeAccessible } from "../src/game/world"
 import { computeTravelTime } from "../src/game/world/travel"
 import {
 	appendUnique,
+	clearPerVisitZoneState,
 	deleteZoneBag,
 	loadEquippedSet,
 	loadOwnedCharacter,
@@ -353,13 +354,8 @@ export const respawnDead = mutation({
 			hpCurrent: maxHp,
 			xp,
 			potions: refilledPotions,
-			currentZoneSession: undefined,
+			...clearPerVisitZoneState(),
 			currentZoneKills: 0,
-			// Server-authoritative camp/phase state is per-visit; clear it on
-			// death so the next enterZone rolls a fresh schedule.
-			zoneStartedAt: undefined,
-			campThresholdsMs: undefined,
-			inCamp: false,
 			// Respawn resets you to the city and clears any in-flight travel.
 			currentLocation: "city",
 			travelDestination: undefined,
@@ -663,10 +659,7 @@ export const useTeleportStone = mutation({
 				teleportStones: stones - 1,
 				hpCurrent: stats.maxLife,
 				potions: refilledPotions,
-				currentZoneSession: undefined,
-				zoneStartedAt: undefined,
-				campThresholdsMs: undefined,
-				inCamp: false,
+				...clearPerVisitZoneState(),
 				travelDestination: "city",
 				travelStartedAt: startedAt,
 				travelArrivesAt: arrivesAt,
@@ -676,10 +669,7 @@ export const useTeleportStone = mutation({
 
 		await ctx.db.patch(args.characterId, {
 			teleportStones: stones - 1,
-			currentZoneSession: undefined,
-			zoneStartedAt: undefined,
-			campThresholdsMs: undefined,
-			inCamp: false,
+			...clearPerVisitZoneState(),
 			travelDestination: destinationNodeId,
 			travelStartedAt: startedAt,
 			travelArrivesAt: arrivesAt,

--- a/convex/items.ts
+++ b/convex/items.ts
@@ -19,7 +19,10 @@
 
 import { ConvexError, v } from "convex/values"
 import { findClassDefinition } from "../src/game/classes/data"
-import { computeBagKeepCap } from "../src/game/combat/constants"
+import {
+	type CombatPhase,
+	computeBagKeepCap,
+} from "../src/game/combat/constants"
 import { INVENTORY_MAX_SLOTS } from "../src/game/inventory/constants"
 import { isBow, isQuiver, isWeapon, planEquip } from "../src/game/items/equipment"
 import { computeCharacterStats } from "../src/game/stats/compute"
@@ -33,19 +36,32 @@ import {
 import { mutation, query } from "./_generated/server"
 import { authComponent } from "./auth"
 
+// Server-authoritative phase derivation — the `phase` arg the three bag
+// mutations accept is ignored in favor of `char.inCamp`. The arg stays only
+// for backwards-compat with branches running in parallel against the same
+// dev deployment. See docs/plans/in-progress.md "Server-authoritative
+// camp/phase derivation".
+function derivePhaseFromCharacter(char: {
+	inCamp?: boolean
+}): CombatPhase {
+	return char.inCamp ? "camp" : "combat"
+}
+
 export const exitZone = mutation({
 	args: {
 		characterId: v.id("characters"),
 		keepIds: v.array(v.id("items")),
-		// Exit phase — drives the bag-retention cap. Camp keeps everything;
-		// combat/exploration cap at 30% of the bag at commit time. See
-		// CONTEXT.md → Bag retention tiers.
+		// TODO(merge): drop phase arg — superseded by inCamp derivation. See
+		// docs/plans/in-progress.md "Server-authoritative camp/phase derivation".
+		// Kept on the validator so branches running in parallel against the
+		// same dev deployment don't break; ignored in the handler below.
 		phase: combatPhaseValidator,
 	},
 	handler: async (ctx, args) => {
 		const authUser = await authComponent.getAuthUser(ctx)
 		if (!authUser) throw new ConvexError("Not authenticated")
 		const char = await loadOwnedCharacter(ctx, authUser._id, args.characterId)
+		const derivedPhase = derivePhaseFromCharacter(char)
 
 		const zoneSession = char.currentZoneSession
 		if (!zoneSession) return { kept: 0, discarded: 0 }
@@ -63,11 +79,12 @@ export const exitZone = mutation({
 
 		// Non-camp exit: 30% cap on items kept (see RETENTION_CAP_FRACTION).
 		// Client mirrors this computation via the same helper, but the server
-		// is authoritative — a tampered client can't widen its share.
-		const cap = computeBagKeepCap(bagItems.length, args.phase)
-		if (args.phase !== "camp" && validKeeps.length > cap) {
+		// is authoritative — a tampered client can't widen its share. Phase
+		// derives from `char.inCamp` (server state), not the client arg.
+		const cap = computeBagKeepCap(bagItems.length, derivedPhase)
+		if (derivedPhase !== "camp" && validKeeps.length > cap) {
 			throw new ConvexError(
-				`Phase cap exceeded: kept ${validKeeps.length} > cap ${cap} for phase ${args.phase}`,
+				`Phase cap exceeded: kept ${validKeeps.length} > cap ${cap} for phase ${derivedPhase}`,
 			)
 		}
 
@@ -99,7 +116,15 @@ export const exitZone = mutation({
 			...toDelete.map((it) => ctx.db.delete(it._id)),
 		])
 
-		await ctx.db.patch(args.characterId, { currentZoneSession: undefined })
+		// Clear the per-visit camp/phase state alongside the zone session so
+		// the next enterZone starts from a clean slate (mirrors the death and
+		// teleport-stone paths in convex/combat.ts).
+		await ctx.db.patch(args.characterId, {
+			currentZoneSession: undefined,
+			zoneStartedAt: undefined,
+			campThresholdsMs: undefined,
+			inCamp: false,
+		})
 		return { kept: validKeeps.length, discarded: toDelete.length }
 	},
 })
@@ -113,16 +138,19 @@ export const pickFromBag = mutation({
 	args: {
 		characterId: v.id("characters"),
 		itemIds: v.array(v.id("items")),
+		// TODO(merge): drop phase arg — superseded by inCamp derivation. See
+		// docs/plans/in-progress.md "Server-authoritative camp/phase derivation".
 		phase: combatPhaseValidator,
 	},
 	handler: async (ctx, args) => {
 		const authUser = await authComponent.getAuthUser(ctx)
 		if (!authUser) throw new ConvexError("Not authenticated")
 		const char = await loadOwnedCharacter(ctx, authUser._id, args.characterId)
+		const derivedPhase = derivePhaseFromCharacter(char)
 
-		if (args.phase !== "camp") {
+		if (derivedPhase !== "camp") {
 			throw new ConvexError(
-				`pickFromBag is camp-only — phase ${args.phase} must commit via exitZone`,
+				`pickFromBag is camp-only — phase ${derivedPhase} must commit via exitZone`,
 			)
 		}
 
@@ -176,16 +204,19 @@ export const discardFromBag = mutation({
 	args: {
 		characterId: v.id("characters"),
 		itemIds: v.array(v.id("items")),
+		// TODO(merge): drop phase arg — superseded by inCamp derivation. See
+		// docs/plans/in-progress.md "Server-authoritative camp/phase derivation".
 		phase: combatPhaseValidator,
 	},
 	handler: async (ctx, args) => {
 		const authUser = await authComponent.getAuthUser(ctx)
 		if (!authUser) throw new ConvexError("Not authenticated")
 		const char = await loadOwnedCharacter(ctx, authUser._id, args.characterId)
+		const derivedPhase = derivePhaseFromCharacter(char)
 
-		if (args.phase !== "camp") {
+		if (derivedPhase !== "camp") {
 			throw new ConvexError(
-				`discardFromBag is camp-only — phase ${args.phase} must commit via exitZone`,
+				`discardFromBag is camp-only — phase ${derivedPhase} must commit via exitZone`,
 			)
 		}
 

--- a/convex/items.ts
+++ b/convex/items.ts
@@ -28,11 +28,13 @@ import { isBow, isQuiver, isWeapon, planEquip } from "../src/game/items/equipmen
 import { computeCharacterStats } from "../src/game/stats/compute"
 import { type EquippedItem, narrowEquippedSlot } from "../src/game/stats/types"
 import {
+	clearPerVisitZoneState,
 	combatPhaseValidator,
 	equippedSlotValidator,
 	fetchInventoryAllocator,
 	loadOwnedCharacter,
 } from "./_shared/character"
+import type { Doc } from "./_generated/dataModel"
 import { mutation, query } from "./_generated/server"
 import { authComponent } from "./auth"
 
@@ -41,9 +43,7 @@ import { authComponent } from "./auth"
 // for backwards-compat with branches running in parallel against the same
 // dev deployment. See docs/plans/in-progress.md "Server-authoritative
 // camp/phase derivation".
-function derivePhaseFromCharacter(char: {
-	inCamp?: boolean
-}): CombatPhase {
+function derivePhaseFromCharacter(char: Doc<"characters">): CombatPhase {
 	return char.inCamp ? "camp" : "combat"
 }
 
@@ -116,15 +116,7 @@ export const exitZone = mutation({
 			...toDelete.map((it) => ctx.db.delete(it._id)),
 		])
 
-		// Clear the per-visit camp/phase state alongside the zone session so
-		// the next enterZone starts from a clean slate (mirrors the death and
-		// teleport-stone paths in convex/combat.ts).
-		await ctx.db.patch(args.characterId, {
-			currentZoneSession: undefined,
-			zoneStartedAt: undefined,
-			campThresholdsMs: undefined,
-			inCamp: false,
-		})
+		await ctx.db.patch(args.characterId, clearPerVisitZoneState())
 		return { kept: validKeeps.length, discarded: toDelete.length }
 	},
 })

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -82,6 +82,13 @@ export default defineSchema({
 		// `phase` arg they still accept is ignored (kept for backwards-compat
 		// during the parallel-branch rollout).
 		inCamp: v.optional(v.boolean()),
+		// Highest camp threshold index consumed so far in the current visit.
+		// enterCamp rejects indices ≤ this so a player can't exit camp and
+		// re-claim an earlier threshold (each one would still pass the
+		// elapsed-time gate, and inCamp would flip back to true on every
+		// replay). Reset on enterZone / exitZone / death / miniboss kill via
+		// clearPerVisitZoneState (and explicitly in the miniboss reroll path).
+		lastCampIndex: v.optional(v.number()),
 	}).index("by_authUserId", ["authUserId"]),
 
 	// All items live here — drops, inventory, equipped, stash. Location is

--- a/convex/schema.ts
+++ b/convex/schema.ts
@@ -67,6 +67,21 @@ export default defineSchema({
 		// fills at 30, resets to 0 on miniboss kill OR on leaving the zone
 		// with the miniboss unsummoned.
 		currentZoneKills: v.optional(v.number()),
+		// Server-authoritative camp/phase derivation — see docs/plans/in-progress.md
+		// "Server-authoritative camp/phase derivation". Set on enterZone, consumed
+		// by enterCamp / exitCamp, cleared on exitZone / death.
+		// `zoneStartedAt` is the wall-clock ms timestamp when enterZone fired —
+		// enterCamp gates `Date.now() - zoneStartedAt >= campThresholdsMs[i]`.
+		zoneStartedAt: v.optional(v.number()),
+		// `campThresholdsMs` is the array of cumulative ms thresholds rolled by
+		// enterZone (from the zone's encounterPlan). Each entry corresponds to
+		// one camp the player can claim by calling enterCamp(thresholdIndex).
+		campThresholdsMs: v.optional(v.array(v.number())),
+		// `inCamp` is the authoritative phase flag. exitZone/pickFromBag/
+		// discardFromBag derive their `phase` from this server-side; the
+		// `phase` arg they still accept is ignored (kept for backwards-compat
+		// during the parallel-branch rollout).
+		inCamp: v.optional(v.boolean()),
 	}).index("by_authUserId", ["authUserId"]),
 
 	// All items live here — drops, inventory, equipped, stash. Location is

--- a/docs/plans/in-progress.md
+++ b/docs/plans/in-progress.md
@@ -10,12 +10,12 @@ When a planned item starts, move it to a feature branch and reference back here.
 
 ## Next session — pick up here
 
-Both monolith refactors are done — world.tsx (PR #45) and useCombatLoop (PR #47, split into `useCombatLoop` + `useCombatTick` + `useEncounterSchedule`). The remaining queued items are queued in priority order:
+Both monolith refactors are done — world.tsx (PR #45) and useCombatLoop (PR #47, split into `useCombatLoop` + `useCombatTick` + `useEncounterSchedule`). Camp/phase derivation closing Threat #3 is now in review on `feat/camp-phase-server`. Remaining queue in priority order:
 
-- **Server-authoritative camp/phase derivation** — closes Threat #3 in the threat model. Next architectural piece for the time-based-zone scope.
 - **Single active session per character** — closes Threat #5 in the threat model (multi-tab races). Same architectural shape as phase derivation (schema add + `sessionToken` arg threaded through every state-mutating mutation + a helper that bundles ownership + session check). **Hard-blocker before any leaderboard / rank ships** — a rank built on multi-tab kills is fraud-by-construction even without intent. Also see the "Convex cost envelope" section below — multi-tab abuse multiplies a single user's function-call cost by tab count.
-- **In-flight tracking for spam-click action handlers** — unblocked now that both splits shipped. Extends the vendor pattern (PR #45) to potion / teleport stone / exit-zone buttons / map travel / incense.
-- **Thorns-reflect bug fix** — small combat-math fix in `useCombatTick.ts`, surfaced by Gemini on PR #47. Standalone PR.
+- **In-flight tracking for spam-click action handlers** — ready on `feat/spam-click-tracking`. Extends the vendor pattern (PR #45) to potion / teleport stone / exit-zone buttons / map travel / incense.
+- **Thorns-reflect bug fix** — ready on `fix/thorns-reflect`. Small combat-math fix in `useCombatTick.ts`, surfaced by Gemini on PR #47.
+- **Drop the `phase` arg from `exitZone` / `pickFromBag` / `discardFromBag`** — once camp/phase merges and the other two branches rebase + merge, the `phase` arg kept as `combatPhaseValidator` (with `TODO(merge)` comments at three validator sites in `convex/items.ts` and five client call sites in `src/routes/world.tsx`) becomes dead weight. Single-PR cleanup: drop the arg, remove the comments, remove the `combatPhaseValidator` import if it has no other users.
 
 ---
 
@@ -58,7 +58,7 @@ This is a self-assessment from senior-review passes after PRs #39 (tooltip i18n 
 If you're picking up where we left off:
 
 1. Read this snapshot first — know where the project sits and what's at stake.
-2. The world.tsx split (PR #45), useCombatLoop split (PR #47), and agent-ergonomics hardening are **done**. The next high-leverage debt is server-authoritative camp/phase derivation (queued entry below).
+2. The world.tsx split (PR #45), useCombatLoop split (PR #47), and agent-ergonomics hardening are **done**. Camp/phase derivation (closing Threat #3) is shipping next. The next high-leverage debt after it merges is the single-active-session lock (queued entry below) — hard-blocker before any leaderboard.
 3. When a major refactor lands, **update the relevant playbook + sentinel in the same PR** (this is the single most important habit for keeping the grade trajectory positive).
 
 ---
@@ -221,42 +221,6 @@ experience. The remaining 40% is in (a) biome-themed background art and
 ### 4. Convex validator can't enforce literal unions
 
 **Constraint, not a bug**. `nameBase` / `nameModifier` are stored as `v.optional(v.string())` because Convex validators don't have ergonomic literal-union support. The in-process `GeneratedItem` type widens to `string` at the persistence boundary — the lexicon files themselves keep the union enforcement. If Convex ever ships a `v.unionLiteral([...])` helper, swap in.
-
----
-
-## Server-authoritative camp/phase derivation (queued)
-
-**Status**: Planned, not started.
-**Why**: PR #40 added server-side enforcement of the 30% bag retention cap by accepting a `phase` arg on `exitZone` / `pickFromBag` / `discardFromBag`. The cap math itself is server-enforced, but the **`phase` arg is still client-trusted**. A tampered client (or someone hitting the Convex endpoint directly via the SDK) can pass `phase: "camp"` while actually in combat and bypass the cap entirely. Auth + ownership are protected; phase is not.
-
-### Why we deferred
-
-This is the next "right" step for the time-based-zone scope, but it requires schema + enterZone + useCombatLoop rewiring. Doing both in the same PR as the world.tsx split (now shipped in PR #45) would have been too much surface for one review.
-
-### Scope
-
-- **Schema** (`convex/schema.ts`): add to `characters`:
-  - `zoneStartedAt?: number` (ms) — set by `enterZone`, cleared by `exitZone`/death.
-  - `campThresholdsMs?: number[]` — rolled by `enterZone`, consumed on `enterCamp`.
-  - `inCamp?: boolean` — set by `enterCamp`, cleared by `exitCamp` / `exitZone`.
-- **`enterZone`**: roll the camp thresholds server-side (move `rollCampThresholdsMs` call from client to server) and persist `zoneStartedAt` + `campThresholdsMs`. Return both to the client so the time bar can render markers.
-- **New `enterCamp` mutation**: takes `thresholdIndex`. Validates `Date.now() - zoneStartedAt >= campThresholdsMs[thresholdIndex]` (with a small grace window for clock drift). Sets `inCamp = true`. Idempotent on the same index.
-- **New `exitCamp` mutation**: clears `inCamp`. Called when the player picks "Seguir em frente" in the camp panel.
-- **`exitZone` / `pickFromBag` / `discardFromBag`**: drop the `phase` arg. Derive phase server-side as `inCamp ? "camp" : "combat"` (combat vs exploration distinction is only cosmetic for the cap — both gate at 30%).
-- **Client (`useCombatLoop` + `world.tsx`)**:
-  - Read `campThresholdsMs` from the character query instead of rolling locally.
-  - Call `enterCamp(thresholdIndex)` when the camp cinematic triggers.
-  - Call `exitCamp` on the "Seguir em frente" handler.
-  - Stop passing `phase` to the three mutations; UI still uses local `combat.phase` to decide which buttons to show (matches the server's derivation, but UI math doesn't gate security).
-
-### Validation
-
-- `npx tsc --noEmit`, `npx vitest run`, `npx convex dev --once`, `npx biome check`.
-- Manual: enter zone, reach camp, observe panel (no client-trusted phase). Then try in DevTools: call `pickFromBag` with no `enterCamp` first — should reject. Verify `enterCamp` rejects if called before the time threshold.
-
-### Why this matters
-
-Without this, the cap is a **client-cooperation** boundary, not a security one. The user's framing in PR #40 — *"backend tem que proteger isso"* — only fully holds once phase derives from server state.
 
 ---
 

--- a/src/hooks/useCombatLoop.ts
+++ b/src/hooks/useCombatLoop.ts
@@ -64,6 +64,11 @@ type Params = {
 	monsterPool: readonly MonsterId[];
 	zoneLevel: number;
 	encounterPlan: ZoneEncounterPlan;
+	// Camp thresholds (cumulative calmaria ms) rolled server-side by enterZone
+	// and persisted on the character. Empty until enterZone resolves — the
+	// ticker simply has no camps to fire during that gap. See
+	// docs/plans/in-progress.md "Server-authoritative camp/phase derivation".
+	serverCampThresholdsMs: readonly number[];
 	active: boolean;
 	onPlayerDeath: () => void;
 };
@@ -80,6 +85,7 @@ export function useCombatLoop({
 	monsterPool,
 	zoneLevel,
 	encounterPlan,
+	serverCampThresholdsMs,
 	active,
 	onPlayerDeath,
 }: Params) {
@@ -106,14 +112,26 @@ export function useCombatLoop({
 	const enemyRef = useRef<Enemy | null>(enemy);
 	enemyRef.current = enemy;
 
+	const enterCamp = useMutation(api.combat.enterCamp);
+	const exitCampMutation = useMutation(api.combat.exitCamp);
+	const enterCampViaIncense = useMutation(api.combat.enterCampViaIncense);
+
 	const schedule = useEncounterSchedule({
 		active,
 		encounterPlan,
+		serverCampThresholdsMs,
 		isSearching: state === "searching",
 		postMinibossPauseRef: lastKillWasMinibossRef,
-		onCampTriggered: () => {
+		onCampTriggered: (thresholdIndex) => {
 			stateRef.current = "acampamento";
 			setState("acampamento");
+			// Persist the camp claim server-side so phase-derived bag mutations
+			// (pickFromBag / discardFromBag / exitZone) accept the camp tier
+			// for this visit. The server validates the time threshold; if the
+			// call rejects (e.g. clock drift past the grace window) we still
+			// keep the cinematic on-screen and let the player retreat — the
+			// 30% cap will apply in that edge case, which is the safe default.
+			enterCamp({ characterId, thresholdIndex }).catch(() => {});
 		},
 	});
 
@@ -206,11 +224,14 @@ export function useCombatLoop({
 	}, [active]);
 
 	// Player chose "Seguir em frente" on the camp modal. Resume the loop.
+	// Server-side `inCamp` flips back to false via exitCamp so the bag-cap
+	// derivation returns to the 30% combat tier.
 	const dismissCamp = useCallback(() => {
 		if (stateRef.current !== "acampamento") return;
 		stateRef.current = "searching";
 		setState("searching");
-	}, []);
+		exitCampMutation({ characterId }).catch(() => {});
+	}, [characterId, exitCampMutation]);
 
 	// Player activated Incenso Etéreo. The gameplay rules (see CONTEXT.md →
 	// Active player input → Incenso Etéreo) gate this:
@@ -247,9 +268,13 @@ export function useCombatLoop({
 		schedule.setCampSource("incense");
 		stateRef.current = "acampamento";
 		setState("acampamento");
+		// Persist the camp claim server-side so the bag mutations see the
+		// camp phase. Incense camps bypass the time-threshold gate.
+		enterCampViaIncense({ characterId }).catch(() => {});
 	}, [
 		characterId,
 		consumeIncense,
+		enterCampViaIncense,
 		incense,
 		schedule.isAmbushPackActive,
 		schedule.cancelAmbush,
@@ -333,11 +358,14 @@ export function useCombatLoop({
 			// Incenso queued during the fight — enter camp instead of the next
 			// spawn. Cancels any in-flight ambush pack so the remaining mobs
 			// don't fire after dismissCamp (per CONTEXT.md → Incenso Etéreo).
+			// The incense was already consumed; persist the camp claim now
+			// that the cinematic actually fires.
 			pendingIncenseRef.current = false;
 			schedule.cancelAmbush();
 			schedule.setCampSource("incense");
 			stateRef.current = "acampamento";
 			setState("acampamento");
+			enterCampViaIncense({ characterId }).catch(() => {});
 		} else {
 			setState("searching");
 		}

--- a/src/hooks/useCombatLoop.ts
+++ b/src/hooks/useCombatLoop.ts
@@ -372,11 +372,16 @@ export function useCombatLoop({
 	});
 
 	// Retreat is handled by the existing active=false transition in the world view.
+	// `recordKill` flipped server `inCamp=true` on the miniboss kill so the
+	// implicit "miniboss victory" tier still grants 100% retention if the
+	// player retreats. Continuing past the panel returns them to combat tier;
+	// `exitCamp` clears the server flag so subsequent bag commits cap at 30%.
 	const dismissMinibossModal = useCallback(() => {
 		if (stateRef.current !== "miniboss_victory") return;
 		stateRef.current = "searching";
 		setState("searching");
-	}, []);
+		exitCampMutation({ characterId }).catch(() => {});
+	}, [characterId, exitCampMutation]);
 
 	return {
 		state,

--- a/src/hooks/useEncounterSchedule.ts
+++ b/src/hooks/useEncounterSchedule.ts
@@ -98,10 +98,13 @@ export function useEncounterSchedule({
 
 	// Shared by the activation effect and resetForMiniboss — zero the time
 	// bar, re-roll ambushes, drain any in-flight pack. Camp thresholds are
-	// not re-rolled here: the server rolls them once on enterZone (and after
-	// miniboss kill the player keeps the existing schedule for the
-	// remaining run, same as before). Activation additionally resets
-	// campSource ("baked") above this call.
+	// owned by the server: enterZone rolls them on entry, and recordKill on a
+	// miniboss reroll them + resets zoneStartedAt per CONTEXT.md → Zone
+	// Miniboss ("the bar resets to 0 and the schedule is rerolled"). The
+	// reactive `serverCampThresholdsMs` prop carries the new values into the
+	// ref via the effect above, so this client-side reset only needs to clear
+	// the consumed-index counter. Activation additionally resets campSource
+	// ("baked") above this call.
 	const resetSchedule = useCallback(() => {
 		calmariaElapsedMsRef.current = 0;
 		setCalmariaElapsedMs(0);

--- a/src/hooks/useEncounterSchedule.ts
+++ b/src/hooks/useEncounterSchedule.ts
@@ -11,7 +11,6 @@ import type { CampSource } from "#/game/world";
 import {
 	type AmbushSchedule,
 	rollAmbushSchedule,
-	rollCampThresholdsMs,
 	rollSpawnGapMs,
 	type ZoneEncounterPlan,
 } from "#/game/world/encounter-schedule";
@@ -25,17 +24,26 @@ const CALMARIA_TICK_MS = 100;
 type Params = {
 	active: boolean;
 	encounterPlan: ZoneEncounterPlan;
+	// Camp thresholds (cumulative calmaria ms). Rolled server-side by
+	// enterZone and persisted on the character — read off the character query.
+	// Empty array while the zone hasn't rolled yet (e.g. mid-load) so the
+	// ticker simply has no camps to fire. See docs/plans/in-progress.md
+	// "Server-authoritative camp/phase derivation".
+	serverCampThresholdsMs: readonly number[];
 	isSearching: boolean;
 	// Held by the state machine; set true between miniboss kill and the
 	// victory-delay transition. Read at render time so the ticker re-evaluates
 	// whenever state flips. A ref (not state) so flips don't trigger renders.
 	postMinibossPauseRef: React.MutableRefObject<boolean>;
-	onCampTriggered: () => void;
+	// Fires with the crossed threshold's index so the parent can call
+	// `enterCamp(thresholdIndex)` against the server.
+	onCampTriggered: (thresholdIndex: number) => void;
 };
 
 export function useEncounterSchedule({
 	active,
 	encounterPlan,
+	serverCampThresholdsMs,
 	isSearching,
 	postMinibossPauseRef,
 	onCampTriggered,
@@ -49,12 +57,15 @@ export function useEncounterSchedule({
 	const [calmariaElapsedMs, setCalmariaElapsedMs] = useState(0);
 	const calmariaElapsedMsRef = useRef(0);
 
-	// State mirror so the bar can render markers at each camp position; ref is
-	// what the ticker reads to avoid stale closures.
-	const [campThresholdsMs, setCampThresholdsMs] = useState<readonly number[]>(
-		[],
-	);
-	const campThresholdsMsRef = useRef<readonly number[]>([]);
+	// Camp thresholds are now server-rolled (enterZone persists them on the
+	// character). We mirror the latest value into a ref so the ticker — which
+	// reads via a ref to avoid stale closures — sees updates from Convex's
+	// reactive query without re-subscribing. The state copy drives the bar
+	// marker render.
+	const campThresholdsMsRef = useRef<readonly number[]>(serverCampThresholdsMs);
+	useEffect(() => {
+		campThresholdsMsRef.current = serverCampThresholdsMs;
+	}, [serverCampThresholdsMs]);
 	const nextCampIndexRef = useRef(0);
 
 	// `ambushPackRemainingRef` is the mobs remaining in the active pack —
@@ -86,14 +97,14 @@ export function useEncounterSchedule({
 	}, [isSearching, encounterPlan, ambushPlan]);
 
 	// Shared by the activation effect and resetForMiniboss — zero the time
-	// bar, re-roll camps + ambushes, drain any in-flight pack. Activation
-	// additionally resets campSource ("baked") above this call.
+	// bar, re-roll ambushes, drain any in-flight pack. Camp thresholds are
+	// not re-rolled here: the server rolls them once on enterZone (and after
+	// miniboss kill the player keeps the existing schedule for the
+	// remaining run, same as before). Activation additionally resets
+	// campSource ("baked") above this call.
 	const resetSchedule = useCallback(() => {
 		calmariaElapsedMsRef.current = 0;
 		setCalmariaElapsedMs(0);
-		const freshCamps = rollCampThresholdsMs(encounterPlan);
-		campThresholdsMsRef.current = freshCamps;
-		setCampThresholdsMs(freshCamps);
 		nextCampIndexRef.current = 0;
 		ambushScheduleRef.current = rollAmbushSchedule(encounterPlan);
 		nextAmbushIndexRef.current = 0;
@@ -123,16 +134,18 @@ export function useEncounterSchedule({
 
 			// Camp fires only if the budget hasn't filled yet — at the budget
 			// boundary the boss-spawn check wins on the next spawn instead.
-			const nextCampThreshold =
-				campThresholdsMsRef.current[nextCampIndexRef.current];
+			const currentCampIndex = nextCampIndexRef.current;
+			const nextCampThreshold = campThresholdsMsRef.current[currentCampIndex];
 			if (
 				nextCampThreshold !== undefined &&
 				next >= nextCampThreshold &&
 				next < calmariaBudgetMs
 			) {
-				nextCampIndexRef.current += 1;
+				nextCampIndexRef.current = currentCampIndex + 1;
 				setCampSource("baked");
-				onCampTriggered();
+				// Pass the index of the threshold the player just crossed so the
+				// parent can call enterCamp(thresholdIndex) against the server.
+				onCampTriggered(currentCampIndex);
 				return;
 			}
 
@@ -188,7 +201,7 @@ export function useEncounterSchedule({
 	return {
 		calmariaElapsedMs,
 		calmariaBudgetMs,
-		campThresholdsMs,
+		campThresholdsMs: serverCampThresholdsMs,
 		campSource,
 		ambushActive,
 		nextSpawnGapMs,

--- a/src/routes/world.tsx
+++ b/src/routes/world.tsx
@@ -84,6 +84,12 @@ function WorldView() {
 	return <WorldLayout character={character} />;
 }
 
+// Stable identity for the "no thresholds yet" case — Convex reactive queries
+// return undefined briefly between mount and the first enterZone result. A
+// fresh `?? []` would allocate a new reference per render, retriggering the
+// downstream ref-sync useEffect in useEncounterSchedule for no reason.
+const EMPTY_THRESHOLDS: readonly number[] = [];
+
 function WorldLayout({ character }: { character: Doc<"characters"> }) {
 	const navigate = useNavigate();
 	const confirm = useConfirmationModal();
@@ -233,7 +239,7 @@ function WorldLayout({ character }: { character: Doc<"characters"> }) {
 		// in lockstep with what enterCamp will accept. See
 		// docs/plans/in-progress.md "Server-authoritative camp/phase
 		// derivation".
-		serverCampThresholdsMs: character.campThresholdsMs ?? [],
+		serverCampThresholdsMs: character.campThresholdsMs ?? EMPTY_THRESHOLDS,
 		// Pause combat while the loot picker is open so the player can't die
 		// mid-selection from a goblin they've already retreated from.
 		active: view === "combat" && !exitModal.isOpen,

--- a/src/routes/world.tsx
+++ b/src/routes/world.tsx
@@ -228,6 +228,12 @@ function WorldLayout({ character }: { character: Doc<"characters"> }) {
 		monsterPool,
 		zoneLevel,
 		encounterPlan,
+		// Camp thresholds are server-rolled by enterZone; the time bar reads
+		// them off the character query so the markers and the ticker stay
+		// in lockstep with what enterCamp will accept. See
+		// docs/plans/in-progress.md "Server-authoritative camp/phase
+		// derivation".
+		serverCampThresholdsMs: character.campThresholdsMs ?? [],
 		// Pause combat while the loot picker is open so the player can't die
 		// mid-selection from a goblin they've already retreated from.
 		active: view === "combat" && !exitModal.isOpen,
@@ -353,6 +359,7 @@ function WorldLayout({ character }: { character: Doc<"characters"> }) {
 			setExitKeepCap(computeBagKeepCap(zoneBag.length, combat.phase));
 			exitModal.open();
 		} else {
+			// TODO(merge): drop phase arg — server derives it from inCamp now.
 			void exitZone({
 				characterId: character._id,
 				keepIds: [],
@@ -367,12 +374,14 @@ function WorldLayout({ character }: { character: Doc<"characters"> }) {
 		// Routing here matches the server gate (pickFromBag rejects non-camp).
 		try {
 			if (combat.phase === "camp") {
+				// TODO(merge): drop phase arg — server derives it from inCamp now.
 				await pickFromBag({
 					characterId: character._id,
 					itemIds: ids,
 					phase: combat.phase,
 				});
 			} else {
+				// TODO(merge): drop phase arg — server derives it from inCamp now.
 				await exitZone({
 					characterId: character._id,
 					keepIds: ids,
@@ -388,6 +397,7 @@ function WorldLayout({ character }: { character: Doc<"characters"> }) {
 	const handleDiscardSelected = async (ids: Id<"items">[]) => {
 		// Camp-only action — the modal hides the button outside camp.
 		if (combat.phase !== "camp") return;
+		// TODO(merge): drop phase arg — server derives it from inCamp now.
 		await discardFromBag({
 			characterId: character._id,
 			itemIds: ids,
@@ -397,6 +407,7 @@ function WorldLayout({ character }: { character: Doc<"characters"> }) {
 
 	const handlePickAll = async (ids: Id<"items">[]) => {
 		try {
+			// TODO(merge): drop phase arg — server derives it from inCamp now.
 			await exitZone({
 				characterId: character._id,
 				keepIds: ids,
@@ -409,6 +420,7 @@ function WorldLayout({ character }: { character: Doc<"characters"> }) {
 	};
 
 	const handleDiscardAll = async () => {
+		// TODO(merge): drop phase arg — server derives it from inCamp now.
 		await exitZone({
 			characterId: character._id,
 			keepIds: [],


### PR DESCRIPTION
## Summary

- Closes **Threat #3** (client-trusted bag-retention phase) in the threat model. `enterZone` now rolls the camp thresholds server-side and persists them on the character; new `enterCamp` / `exitCamp` / `enterCampViaIncense` mutations gate the camp tier behind elapsed-time validation; `exitZone` / `pickFromBag` / `discardFromBag` derive phase from `char.inCamp` server-side instead of trusting the client-supplied arg.
- The client time bar reads `character.campThresholdsMs` straight off the character query, so the markers and the ticker stay in lockstep with what `enterCamp` will accept.
- The `phase` arg is **kept on the validator** (with `TODO(merge)` comments) so the two parallel branches against the same dev deployment (`feat/spam-click-tracking` and `fix/thorns-reflect`) don't break while they rebase + merge. Single follow-up PR drops the arg after both rebase.

## What changed

- **`convex/schema.ts`** — `characters` gains three optional fields: `zoneStartedAt`, `campThresholdsMs`, `inCamp`.
- **`convex/combat.ts`** — `enterZone` rolls thresholds server-side and persists them; new `enterCamp` (time-gated, 500ms grace, idempotent on same index), `exitCamp` (no gate), `enterCampViaIncense` (bypasses time gate). `respawnDead` and both `useTeleportStone` branches clear the new fields via the new `clearPerVisitZoneState()` helper. `recordKill` flips `inCamp=true` on miniboss kill so the implicit "miniboss-victory" tier still grants 100% retention.
- **`convex/items.ts`** — `derivePhaseFromCharacter(char)` derives `phase` from `char.inCamp` for all cap math and gating. `exitZone` clears the per-visit fields on commit.
- **`convex/_shared/character.ts`** — new `clearPerVisitZoneState()` helper, single source of truth for the per-visit field reset.
- **`src/hooks/useEncounterSchedule.ts`** — drops the client-side `rollCampThresholdsMs` call; reads thresholds from a new `serverCampThresholdsMs` prop and mirrors into a ref via `useEffect` so the ticker sees updates without re-subscribing. `onCampTriggered` now passes the threshold index.
- **`src/hooks/useCombatLoop.ts`** — calls `enterCamp(thresholdIndex)` on a baked camp trigger; calls `exitCamp` on `dismissCamp` AND on `dismissMinibossModal` (the latter caught by the simplify review — without it the server `inCamp=true` from `recordKill` would leak into resumed combat). Incense paths call `enterCampViaIncense`.
- **`src/routes/world.tsx`** — passes `character.campThresholdsMs ?? EMPTY_THRESHOLDS` (stable identity for the no-thresholds-yet case) to `useCombatLoop`.

## Test plan

- [ ] Type check passes (`pnpm exec tsc --noEmit`)
- [ ] Vitest passes (`pnpm exec vitest run` — 517/517)
- [ ] Convex deploy succeeds (`npx convex dev --once`)
- [ ] Manual: enter a fresh zone — camp threshold markers appear on the time bar
- [ ] Manual: bar fills past a threshold — camp panel auto-opens (no incense needed)
- [ ] Manual: "Seguir em frente" returns to combat; `inCamp` server-side flips back
- [ ] Manual: incense still triggers camp regardless of threshold position
- [ ] Manual: retreat / exit zone — `inCamp`, `zoneStartedAt`, `campThresholdsMs` cleared; re-entering rolls fresh thresholds
- [ ] Manual: kill miniboss → continue past the panel → fight a regular mob → retreat → bag caps at 30% (blocker fix from the simplify review)
- [ ] Anti-cheat: in DevTools, try `pickFromBag` without entering camp → server rejects via `derivedPhase !== "camp"`
- [ ] Anti-cheat: in DevTools, try `enterCamp(0)` before the first threshold's elapsed time → server rejects with `Camp threshold not reached`

🤖 Generated with [Claude Code](https://claude.com/claude-code)