### PR TITLE
docs(align): realign meta-docs with reality + add doc-update discipline

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -10,6 +10,38 @@ Read these in order if you're new to the codebase:
 4. **[docs/plans/in-progress.md](./docs/plans/in-progress.md)** — decisions made but not yet executed. Check before starting work to avoid colliding with a planned refactor.
 5. **[docs/adr/](./docs/adr/)** — architecture decisions (optimistic mutations, three-system i18n split, render-at-display naming, static-data conventions).
 
+## Doc-update discipline (read this before you ship)
+
+**The docs are part of the codebase, not a wiki.** Treat doc updates as part of the change, not a follow-up — the docs that drift first are the ones that get stale fastest, and a stale `CONTEXT.md` / `codebase-map.md` is what makes the next agent burn 30 minutes grepping for files that moved. There is no CI gate enforcing this (no `.github/workflows/` exists yet); the discipline is the only guard.
+
+**Update docs in the same PR as the code change. Concretely:**
+
+| If your PR… | Update… |
+|---|---|
+| Adds, removes, or renames a file/directory referenced in `docs/codebase-map.md` | The matching table row(s) in `codebase-map.md` |
+| Changes a game-design rule (combat formula, drop rate, balance number, retention tier, etc) | The relevant section of `CONTEXT.md` — that file is the single source of truth |
+| Ships a queued item from `docs/plans/in-progress.md` | Remove (or rewrite) the queued entry; closed work belongs in commit history, not this file |
+| Materially changes line counts the docs cite (a refactor that breaks a "currently N lines" claim) | The cited number(s) in `codebase-map.md` and `in-progress.md` |
+| Adds a new system that didn't exist before (skill, passive node, stash, leaderboard, etc) | Write a new playbook under `docs/playbooks/` + a sentinel under `_examples/` + a `CONTEXT.md` section. If the choice is load-bearing, write a new ADR under `docs/adr/` |
+| Changes the shape of a type that a playbook documents (Modifier, Template, Monster, Zone, Class) | The sentinel under `docs/playbooks/_examples/` AND the playbook's example block. `tsc --noEmit` will fail otherwise |
+| Reverses an architectural decision already in an ADR | Append an "Update" or "Superseded by" note to the existing ADR; do NOT silently rewrite it |
+| Closes a threat in `docs/security/threat-model.md` | Mark the threat closed inline, link the PR/commit |
+
+**Triggers that mean "find the doc and update it":**
+
+- A reviewer comment says "this contradicts CONTEXT.md / the playbook / the ADR" — that's the doc asking to be updated, not the code.
+- You introduce a new convention (file naming, import style, modifier weight band, etc) — write it down in `CLAUDE.md` or the playbook, or it will be re-litigated by the next agent.
+- You discover a divergence between docs and code while working — fix the doc in the same PR even if it's tangential. Drift compounds; small fixes prevent it.
+
+**Validation before merging a PR that touched docs:**
+
+- `npx tsc --noEmit` — the playbook sentinels live under `tsconfig.json`'s include glob, so type drift in `docs/playbooks/_examples/*.ts` fails here. This is the only automated gate against playbook drift.
+- Manual: grep for the renamed file or moved directory across `docs/` and make sure no other doc still references the old path.
+
+When in doubt, **prefer updating an existing doc to creating a new one**. The orientation tree (`CONTEXT.md` → `codebase-map.md` → playbooks → ADRs) is the established place to look — fragmenting it makes the next agent slower, not faster.
+
+---
+
 ## Tech Stack
 
 - **Frontend:** React + TypeScript + Tailwind CSS + TanStack Router
@@ -45,11 +77,19 @@ src/game/items/
 │   │   ├── resistances.ts     # Cold/fire/lightning/void resistance
 │   │   ├── attributes.ts      # Str/dex/int
 │   │   ├── utility.ts         # Movement speed, leech, stun, light radius
+│   │   ├── tome.ts            # Tome-exclusive `% Spell Damage as Extra <Element>`
 │   │   ├── magic-find.ts      # Item rarity (prefix + suffix)
+│   │   ├── affix-ids.ts       # PrefixModifierId / SuffixModifierId literal unions (lexicon coverage)
 │   │   └── index.ts           # Aggregates all modifiers into MODIFIERS, exports helpers
-│   └── templates.ts     # Equipment base templates (weapons, armor, jewelry)
+│   └── templates/       # Equipment base templates — one file per weapon type + per armor slot + per jewelry slot
+├── lexicon/             # Per-locale display-name data (en.ts, pt.ts, types.ts, template-ids.ts)
 ├── generator.ts         # Item generation logic (public API: generateItem())
-└── generator.test.ts    # 71 tests
+├── generator.test.ts    # 93 tests
+├── item-name.ts         # Display-time renderer (locale × rarity × seed)
+├── mod-i18n.ts          # Explicit/implicit mod-line formatters
+├── equipment.ts         # planEquip, weaponArchetype, isTwoHanded — shared client+server
+├── sell-price.ts        # Vendor sell-price formula (per-act, ilvl + mod quality)
+└── starter-gear.ts      # Hand-crafted starter weapons
 ```
 
 ### How to Add a New Modifier

--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -245,12 +245,14 @@ A hit is computed in this order:
 
 ### Defenses
 
-**Armor** (physical mitigation, Last Epoch-inspired):
+**Armor** (physical mitigation, PoE-style):
 ```
-physicalReduction = armor / (armor + 10 × enemyLevel)
+physicalReduction = armor / (armor + 10 × physicalHit)
 cap = 85%
 ```
-The denominator scales with the attacker's level, **not** with hit size. Armor stays effective against same-level enemies regardless of how big any single hit is — unlike PoE, where armor falls off against spikes. Armor reduces only physical damage; elemental and void pass through untouched.
+The denominator scales with the **size of the incoming hit**, not with the attacker's level. The same armor pool mitigates many small hits hard but barely dents one big hit — armor reads as a "tank against trash" stat, not a flat damage multiplier. Armor reduces only physical damage; elemental and void pass through untouched.
+
+Historical note: an earlier prototype used a Last-Epoch-style denominator (`armor + 10 × enemyLevel`), which made a single chestplate produce ~90% physical reduction in Act 1 and rendered the character effectively immortal against trash. The PoE-style pivot exists to force build diversification (armor + barrier + resistances + evasion) instead of one stat solving everything. The build pressure this assumes only fully materializes once a big-hit source exists on the monster side — monster crit is queued in `docs/plans/in-progress.md` and gates the next balance pass.
 
 **Evasion + Accuracy** (hit-or-miss gate, applied before damage):
 ```

--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -46,23 +46,27 @@ No React. No Convex. Same code runs on client and server (convex imports from he
 | `inventory/` | Inventory constants + helpers | `constants.ts` (INVENTORY_MAX_SLOTS, bySlotAsc) |
 | `items/` | Item generator, modifier data, equip helpers, lexicon | See below — the biggest subdir |
 | `loot/` | Drop tables | `drops.ts` (rollDrop, rollMonsterLevel) |
-| `monsters/` | Monster definitions | `data.ts`, `types.ts` |
+| `monsters/` | Monster definitions, modifier pool, instance-level scaler | `data.ts`, `types.ts`, `modifiers.ts` (pool + roll), `scaling.ts` (geometric 1.06^L) |
 | `progression/` | XP curves, death penalty | `levels.ts` (xpToNextLevel, applyXpGain, applyDeathXpPenalty) |
 | `stats/` | The stat engine | `compute.ts` (computeCharacterStats), `types.ts` (EquippedSlot, narrowEquippedSlot, ComputedCharacterStats) |
-| `world/` | Acts, zones, node graph, zone-name i18n, monster-name lexicon | `act-1.ts`, `index.ts`, `types.ts`, `i18n.ts`, `lexicon/{en,pt,types}.ts` |
+| `vendor/` | Vendor catalog data | `products.ts` (`VENDOR_PRODUCTS`, `VendorProductId`) |
+| `world/` | Acts, zones, node graph, zone-name i18n, monster-name lexicon, travel + encounter-schedule helpers | `act-1.ts`, `index.ts`, `types.ts`, `i18n.ts`, `travel.ts`, `encounter-schedule.ts`, `lexicon/{en,pt,types}.ts` |
 
 ### `src/game/items/` — item subsystem detail
 
 ```
 items/
 ├── generator.ts             # generateItem({ rarity, ilvl, type, weaponType }) — public API
-├── generator.test.ts        # 70+ tests covering rarity/tier/mod rules
+├── generator.test.ts        # 93 tests covering rarity/tier/mod rules
 ├── equipment.ts             # planEquip, validSlotsForItem, isTwoHanded, weaponArchetype — shared client+server
 ├── equipment.test.ts        # planEquip rules (2H displacement, archetype, etc.)
 ├── starter-gear.ts          # Hand-crafted starter weapons (rusty_sword, rusty_dagger, cracked_wand)
 ├── item-name.ts             # translateItemName / translateTemplateName — display-time renderer (locale × rarity, UUID-seeded rare names)
 ├── item-name.test.ts        # 20 tests: gender concord, UUID determinism, locale switch, fallback
 ├── mod-i18n.ts              # PT formatters for explicit mods + implicit pattern-match (tooltip mod lines)
+├── sell-price.ts            # Vendor sell-price formula (rarity × ilvl × mod-quality sum)
+├── sell-price.test.ts       # Sell-price scenarios per rarity/ilvl/mod tier
+├── translation-coverage.test.ts  # Snapshot test guarding every TemplateBaseId / TemplateModifierId has an en + pt entry
 ├── MODIFIER_GUIDELINES.md   # Notes on individual modifier semantics (crit, leech)
 ├── data/
 │   ├── modifiers/           # One file per category — defines the modifier pool
@@ -122,8 +126,10 @@ The spine of every gameplay calculation. Read this if you're touching anything t
 | `combat.ts` | Combat + travel mutations: `recordKill`, `usePotion`, `useEtherealIncense`, `syncHp`, `respawnDead`, `enterZone`, `enterCity`, `startTravel`, `arriveAtTravel`, `useTeleportStone`. Largest convex file (~570 lines) |
 | `items.ts` | Item lifecycle mutations: `exitZone`, `pickFromBag` / `discardFromBag` / `discardFromInventory`, `equipItem` / `unequipItem`, `reorderInventory`, and the `zoneBag` / `inventory` / `equipped` queries |
 | `vendor.ts` | Vendor mutations: `vendorBuy` (potions for Rubys), `vendorSellMany` (gear for Rubys) |
+| `admin.ts` | Admin-only queries (`pulse`, `listUsers`, `listAdmins`, `listRecentItems`) powering `/admin`. Each handler starts with `assertAdmin(ctx)` — route guards are UX, not security |
 | `itemValidator.ts` | Convex validator for the `GeneratedItem` shape in `items.data` |
-| `auth.ts`, `auth.config.ts`, `users.ts` | better-auth integration + user role queries |
+| `_shared/character.ts` | Cross-mutation helpers: `loadOwnedCharacter`, `loadEquippedSet`, etc. The ownership check used by every state-mutating mutation |
+| `auth.ts`, `auth.config.ts`, `users.ts` | better-auth integration + user role queries (`assertAdmin`, role grant/revoke) |
 | `http.ts` | Auth callback routes |
 
 Convex imports from `src/game/*` use **relative paths** (`../src/game/...`), not the `#/` alias — that's a Convex bundler quirk. Don't mix.
@@ -151,16 +157,23 @@ Convex imports from `src/game/*` use **relative paths** (`../src/game/...`), not
 | `MapScene.tsx` | Act DAG rendering, hoverable nodes |
 | `CombatScene.tsx` | Enemy display, HP bars, **floating damage popups** (framer-motion) |
 | `CityScene.tsx` | City hub placeholder |
+| `CampCinematic.tsx` | Inline camp cinematic — text fade-in, ambient SFX, two-button modal (Retornar / Seguir). See CONTEXT.md → Acampamento |
+| `HitFx.tsx` | Weapon-archetype-aware hit effects (slash / impact / magic) layered over the enemy on each player swing |
 | `EquipmentPanel.tsx` | Right-side paper doll (always-visible) |
 | `StatusCard.tsx` | Right-side stat readout + Show button + potion + HP globe |
 | `HealthGlobe.tsx` | Animated HP/barrier orb |
 | `TextLog.tsx` | Status line (priority chain: death → +XP → low HP → zone name) |
+| `MonsterTooltip.tsx` | Hover tooltip over the enemy sprite — translated name + mod descriptions |
+| `RubyCounter.tsx` | Display-only ruby balance pinned bottom-right of the equipment panel |
+| `TravelProgressBar.tsx` | Bottom-of-view bar during travel — survives refresh via `travelArrivesAt` |
 | `InventoryModal.tsx` | The big one — drag-drop equip, click dropdown, 60-slot grid |
 | `ItemContextMenu.tsx` | Popover menu for click-to-equip |
 | `BagPreviewModal.tsx` | Read-only loot bag during combat |
 | `ExitZoneModal.tsx` | Post-retreat loot picker (5 buttons, selection grid) |
+| `VendorModal.tsx` | Per-act vendor — buy consumables / sell inventory gear for Rubys |
 | `ShowStatsModal.tsx` | Full character sheet (4 sections, PoE-style) |
-| `SettingsModal.tsx` | Language dropdown |
+| `SettingsModal.tsx` | Language dropdown + SFX volume slider |
+| `WorldModals.tsx` | Sibling that owns the modal mount-points (BagPreview / ExitZone / Inventory / Vendor / Settings) — keeps `world.tsx` lean |
 | `InventoryButton.tsx` | Backpack icon button on EquipmentPanel |
 
 ---
@@ -173,7 +186,7 @@ Convex imports from `src/game/*` use **relative paths** (`../src/game/...`), not
 | `index.tsx` | Splash screen ("Shadows of Void" title) |
 | `sign-in.tsx` | better-auth UI |
 | `character-select.tsx` | Roster + create modal + play button + delete confirm |
-| `world.tsx` | **Orchestrator** — combat hook, all modals, optimistic mutations, priority TextLog. Currently 900 lines; split in progress (see [`docs/plans/in-progress.md`](./plans/in-progress.md)) |
+| `world.tsx` | **Orchestrator** — wires `useCombatLoop` + `useWorldMutations` + `useViewMode` + `WorldModals` together and resolves the priority TextLog. 740 lines (split shipped in PR #45 + #52; was 900 before decomposition) |
 | `admin.tsx`, `admin/items.tsx` | Admin dashboard (only admins see) |
 | `api/auth/$.ts` | better-auth fallback route |
 
@@ -183,7 +196,13 @@ Convex imports from `src/game/*` use **relative paths** (`../src/game/...`), not
 
 | Hook | Purpose |
 |---|---|
-| `useCombatLoop.ts` | Tick orchestrator (50ms intervals, refs for sync state, search/engaged/victory state machine). Currently 916 lines — largest single file in the repo; split queued after world.tsx (see [`docs/plans/in-progress.md`](./plans/in-progress.md)) |
+| `useCombatLoop.ts` | State-machine orchestrator (search → engaged → victory). Owns the spawn loop + zone-bag side effects. 411 lines (split shipped in PR #47 into the three hooks below) |
+| `useCombatTick.ts` | Engaged-state combat tick (50ms): leech heal → barrier recovery → player swing → enemy swing → thorns. Owns player vitals (HP, barrier, leech, dead) + the 10s `syncHp` + the potion mutation. 420 lines |
+| `useEncounterSchedule.ts` | Per-activation encounter pacing — calmaria time bar, camp threshold rolls, ambush packs, gap rolls, next-spawn rarity decision. 218 lines |
+| `useWorldMutations.ts` | Optimistic mutation bundle for the `/world` route (enterZone, exitZone, pickFromBag, equipItem, etc). See [ADR 0001](./adr/0001-optimistic-mutations.md) |
+| `useViewMode.ts` | View-mode state machine (`"map" | "city" | "combat"`) + the pendingArrival token + the auto-arrival / refresh-resilience effects |
+| `useInFlight.ts` | Spam-click protection: `run(fn)` is a no-op while an earlier call is in flight. Used by every modal action button and world mutation site |
+| `useSfxVolume.ts` | `useSyncExternalStore` binding for the global SFX volume (consumed by HUD + settings + HitFx) |
 | `useCachedQuery.ts` | localStorage-backed wrapper around `useQuery` (cache version-tagged) |
 | `useConfirmationModal.tsx` | Promise-returning confirm() — works because of the ConfirmationProvider in `__root.tsx` |
 | `useModal.ts` | Open/close state for a single modal |

--- a/docs/plans/in-progress.md
+++ b/docs/plans/in-progress.md
@@ -20,21 +20,21 @@ PR #52 landed world.tsx at 740 lines (down from 774, the original monolith was 9
 
 ---
 
-## Project health snapshot (as of 2026-05-23)
+## Project health snapshot (as of 2026-05-24)
 
 **Current grade: A** (composite across architecture / code quality / docs / scalability / agent ergonomics).
 
-This is a self-assessment from senior-review passes after PRs #39 (tooltip i18n + slot-aware mods), #41 (decomposed item-name lexicon + 20 renderer tests), #42 (playbook + codebase-map refresh), the agent-ergonomics-hardening pass (sentinel CI gate against playbook drift, stub playbooks for queued Future domains, ADRs 0002 + 0003), and PR #45 (world.tsx split into `useWorldMutations` + `useViewMode` hooks and a `WorldModals` sibling, plus the shared `createInventorySlotAllocator` lift). The grade exists to give downstream agents a quick read on what's solid and what's debt — pick work that moves the needle, skip work that doesn't.
+This is a self-assessment from senior-review passes after PRs #39 (tooltip i18n + slot-aware mods), #41 (decomposed item-name lexicon + 20 renderer tests), #42 (playbook + codebase-map refresh), the agent-ergonomics-hardening pass (type-check sentinels for playbook drift via `tsc --noEmit` over `docs/playbooks/_examples/`, stub playbooks for queued Future domains, ADRs 0002 + 0003), and PR #45 (world.tsx split into `useWorldMutations` + `useViewMode` hooks and a `WorldModals` sibling, plus the shared `createInventorySlotAllocator` lift). The grade exists to give downstream agents a quick read on what's solid and what's debt — pick work that moves the needle, skip work that doesn't.
 
 ### Why A (criteria that earned the current grade)
 
 - **Architecture: A-** — render-at-display-time naming + literal-union enforcement is the correct choice for a multi-locale ARPG (codified now in [ADR 0003](../adr/0003-render-at-display-names.md)). Lexicon pattern is battle-tested across two domains (monsters + items). Convex/TanStack split is coherent. Remaining hole: drift risk between lexicon and `mod-i18n.ts` (same modifier id in two independent tables) — flagged in the lexicon follow-ups below.
-- **Code quality: A** — `src/game/` is pure + tested. 334 vitest cases. Comments are WHY-focused. One remaining stain: residual `as TemplateBaseId` casts at the Convex boundary (Convex validators can't express literal unions — captured in [ADR 0003](../adr/0003-render-at-display-names.md)). The world.tsx orchestrator dropped from 900 → 645 lines via PR #45.
-- **Docs: A** — `CONTEXT.md` is best-in-class for a solo-dev project (879 lines of single-source-of-truth game rules). Three ADRs codify the load-bearing architectural decisions (optimistic mutations, three-system i18n, render-at-display naming). Playbooks accurate and link to type-checked sentinel examples; new system stubs let an agent picking up skills / passives / stash know which questions need answering before coding.
+- **Code quality: A** — `src/game/` is pure + tested. 288 vitest cases. Comments are WHY-focused. One remaining stain: residual `as TemplateBaseId` casts at the Convex boundary (Convex validators can't express literal unions — captured in [ADR 0003](../adr/0003-render-at-display-names.md)). The world.tsx orchestrator dropped from 900 → 740 lines via PR #45 + PR #52.
+- **Docs: A** — `CONTEXT.md` is best-in-class for a solo-dev project (976 lines of single-source-of-truth game rules). Three ADRs codify the load-bearing architectural decisions (optimistic mutations, three-system i18n, render-at-display naming). Playbooks accurate and link to type-checked sentinel examples; new system stubs let an agent picking up skills / passives / stash know which questions need answering before coding.
 - **Scalability: A** — adding a new locale = 1 new lexicon file per domain + matching paraglide JSON. Adding a new template = 1 entry + 0 lexicon changes if base/modifier already exist. Decomposition cut lexicon size by 88% (562 → 135). Literal-union enforcement makes "forgot a translation" a compile error.
 - **Translation quality: B-** — 130 PT lexicon entries were AI-bulk-translated. Four hand-revised (Espada Bastarda, Estrela da Manhã, Maculado pelo Vazio, Gume) caught real awkwardness, so the rest probably has 5–10 similar issues. Fine for indie pre-release, not for a paid Brazilian release.
 - **Agent ergonomics for ONBOARDING: A+** — `CONTEXT.md` + `CLAUDE.md` + `codebase-map.md` get an agent productive in ~30 minutes.
-- **Agent ergonomics for MODIFYING existing things: A+** — strong TS catches mistakes. Both monolith refactors have shipped: world.tsx from 900 → 645 lines (PR #45), `useCombatLoop.ts` from 916 → 378 lines split into `useCombatLoop` + `useCombatTick` + `useEncounterSchedule` (PR #47). No remaining single-file navigation tax above ~600 lines.
+- **Agent ergonomics for MODIFYING existing things: A+** — strong TS catches mistakes. Both monolith refactors have shipped: world.tsx from 900 → 740 lines (PR #45 + PR #52), `useCombatLoop.ts` from 916 → 411 lines split into `useCombatLoop` + `useCombatTick` + `useEncounterSchedule` (PR #47). No remaining single-file navigation tax above ~750 lines, and the styleguide now distinguishes "concerns re-mixing" (real debt) from "line growth" (not debt).
 - **Agent ergonomics for ADDING NEW systems (skills, passive tree, stash): B** — stub playbooks now exist for each queued Future domain, listing the decisions to resolve + the ADRs the agent will need to write. The systems themselves aren't built, but the orientation infrastructure is. The grade returns to A once the first new system ships against its stub without an emergency refactor.
 
 ### What raises the grade
@@ -48,7 +48,7 @@ This is a self-assessment from senior-review passes after PRs #39 (tooltip i18n 
 
 | Risk | Drop |
 |---|---|
-| Next major refactor ships without updating relevant playbooks (drift recurs) | A → B+. The sentinel CI gate covers the playbook code blocks — but a refactor that *also* changes the surrounding prose without updating it is still possible. |
+| Next major refactor ships without updating relevant playbooks (drift recurs) | A → B+. The type-check sentinels under `docs/playbooks/_examples/` cover the playbook code blocks via `tsc --noEmit` — but a refactor that *also* changes the surrounding prose without updating it is still possible, and there is no CI workflow that enforces `tsc` on push (no `.github/workflows/` yet — local discipline is the only guard). |
 | New domain shipped that ignores its stub playbook (and doesn't write the ADRs it flagged) | Scalability slips A → B+. The first system to do this sets a precedent that's hard to walk back. |
 | `world.tsx` grows further (or another orchestrator route hits the same shape) | Modifying existing → B+. Agent navigation tax compounds. |
 | Someone "optimizes" render-at-display by pre-rendering names | Locale switching silently breaks. Now explicitly forbidden by [ADR 0003](../adr/0003-render-at-display-names.md). |
@@ -59,8 +59,8 @@ This is a self-assessment from senior-review passes after PRs #39 (tooltip i18n 
 If you're picking up where we left off:
 
 1. Read this snapshot first — know where the project sits and what's at stake.
-2. The world.tsx split (PR #45), useCombatLoop split (PR #47), and agent-ergonomics hardening are **done**. Camp/phase derivation (closing Threat #3) is shipping next. The next high-leverage debt after it merges is the single-active-session lock (queued entry below) — hard-blocker before any leaderboard.
-3. When a major refactor lands, **update the relevant playbook + sentinel in the same PR** (this is the single most important habit for keeping the grade trajectory positive).
+2. world.tsx split (PR #45), useCombatLoop split (PR #47), camp/phase derivation (PR #48, closed Threat #3), thorns-reflect fix (PR #49), spam-click in-flight tracking (PR #50), phase-arg cleanup (PR #51), and `useInFlight` extraction (PR #52) are all **done**. The next high-leverage debt is the single-active-session lock (queued entry below) — hard-blocker before any leaderboard.
+3. When a major refactor lands, **update the relevant playbook + sentinel + codebase-map + CONTEXT.md + this file in the same PR** (this is the single most important habit for keeping the grade trajectory positive — see the "Doc-update discipline" section in `CLAUDE.md`).
 
 ---
 

--- a/docs/playbooks/README.md
+++ b/docs/playbooks/README.md
@@ -40,8 +40,10 @@ npx convex dev --once  # one-shot deploy check
 
 Don't bypass these. If a check fails, fix it before adding more changes.
 
-## CI gate against drift
+## Type-check gate against drift
 
-The playbooks for adding a modifier / template / monster / zone / class each link to a sentinel file under [`_examples/`](./_examples/) that mirrors the exact compile-checked shape. The sentinels are part of the regular `tsc --noEmit` pass — if a future refactor changes a domain type in an incompatible way, the matching sentinel fails and the playbook must be updated in the same PR.
+The playbooks for adding a modifier / template / monster / zone / class each link to a sentinel file under [`_examples/`](./_examples/) that mirrors the exact compile-checked shape. The sentinels are included in `tsconfig.json` (via `**/*.ts`) so `npx tsc --noEmit` fails on the sentinel when a domain type changes incompatibly — the playbook must then be updated in the same PR.
+
+**Caveat — this is a local-only gate, not CI.** There is no `.github/workflows/` in the repo today, so nothing automatically runs `tsc --noEmit` on push. The sentinel only fires when *you* (or a reviewing agent) run the validation sequence above before merging. If a PR lands without that run, a stale sentinel can ship undetected. Treat the discipline as load-bearing until a CI workflow gets wired up.
 
 When you change a domain shape **or** when you change a playbook example, update both. The sentinels exist to make that coupling hard to forget.

--- a/docs/playbooks/_examples/README.md
+++ b/docs/playbooks/_examples/README.md
@@ -1,4 +1,4 @@
-# Playbook examples — CI gate against doc drift
+# Playbook examples — type-check gate against doc drift
 
 The files in this folder are **sentinel examples** referenced by the playbooks
 in `docs/playbooks/`. Each one imports the real game types and declares a
@@ -8,6 +8,12 @@ They're part of the regular `tsc --noEmit` pass (`tsconfig.json` includes
 `**/*.ts`), so if a future refactor changes a domain type in an
 incompatible way, the corresponding example breaks and the playbook is
 forced to update in the same PR.
+
+**Caveat — local-only enforcement.** No `.github/workflows/` exists in the
+repo, so nothing runs `tsc --noEmit` automatically on push. The gate only
+fires when you (or a reviewing agent) run the validation sequence locally
+before merging. Until a CI workflow is wired up, the discipline of running
+the validation suite is the only thing keeping the sentinels honest.
 
 Each example is a plain `.ts` file with one exported constant and no
 side effects. They are NOT registered anywhere in the runtime — nothing

--- a/docs/security/threat-model.md
+++ b/docs/security/threat-model.md
@@ -62,7 +62,11 @@ setInterval(() => convex.mutation("combat:syncHp", { characterId, hpCurrent: 999
 
 **Why it works**: `syncHp` was designed as "send your local HP for persistence" with no validation that the local HP is a plausible result of the combat that happened since the last sync.
 
-### 3. `phase` arg trust → bag retention cap bypass (MEDIUM severity)
+### 3. `phase` arg trust → bag retention cap bypass (MEDIUM severity) — **CLOSED in PR #48 + #51**
+
+**Resolution**: server-authoritative camp/phase derivation shipped in PR #48; the `phase` argument was removed entirely from `exitZone` / `pickFromBag` / `discardFromBag` in PR #51 (`derivePhaseFromCharacter` reads the server's own combat/exploration/camp state). The historical record below is kept for reference — the rest of this section describes the pre-fix behaviour.
+
+---
 
 `exitZone`, `pickFromBag`, and `discardFromBag` accept a `phase` argument that drives the bag-retention cap (camp = 100%, exploração / combate = 30%). The server enforces the cap math correctly for non-camp phases (PR #40), but the `phase` arg itself is **client-supplied** and unvalidated against server state.
 
@@ -221,10 +225,10 @@ The architecture is currently fine for "MVP closed development". Don't preemptiv
 
 These close a specific exploit without depending on the broader rate-limit / session-combat infrastructure. Each is independent; ship in any order.
 
-| Fix | Closes | Trigger |
+| Fix | Closes | Status |
 |---|---|---|
-| Server-authoritative camp/phase derivation (see `docs/plans/in-progress.md`) | Threat #3 (`phase` arg trust) | Combat-hook surface stabilises after the useCombatLoop split |
-| Single active session per character (see `docs/plans/in-progress.md`) | Threat #5 (multi-tab) | **First competitive feature ships (leaderboard / rank / shared ladder)**. Pre-leaderboard the bug is annoying; post-leaderboard it is fraud-by-construction. |
+| Server-authoritative camp/phase derivation | Threat #3 (`phase` arg trust) | ✅ **Shipped** in PR #48 + PR #51 — `derivePhaseFromCharacter` reads server state; `phase` arg removed from all mutations. |
+| Single active session per character (see `docs/plans/in-progress.md`) | Threat #5 (multi-tab) | Queued. **Trigger: first competitive feature ships (leaderboard / rank / shared ladder).** Pre-leaderboard the bug is annoying; post-leaderboard it is fraud-by-construction. |
 
 ---
 


### PR DESCRIPTION
## Summary

- **Audit + fix**: every meta-doc was checked against the actual codebase. Found seven kinds of drift (file inventory in `codebase-map.md`, stale armor formula in `CONTEXT.md`, stale line counts + vitest count + snapshot date in `in-progress.md`, stale `useInFlight` queued entry hangover, stale Threat #3 status in `threat-model.md`) — all fixed.
- **CI claim corrected**: docs referred to a "sentinel CI gate" but no `.github/workflows/` exists. Sentinels live under `tsconfig` and only fire via local `tsc --noEmit`. Reframed as "type-check sentinels" with an explicit local-only caveat so no agent assumes an automated guard that does not exist.
- **New discipline**: `CLAUDE.md` grows a `Doc-update discipline` section at the top with a trigger → target table — what to update when a PR adds/moves files, changes a design rule, ships a queued entry, breaks a cited line count, adds a system, mutates a typed shape (sentinels), reverses an ADR, or closes a threat. The validation sequence is the only automated gate today; the table makes the manual work explicit so it cannot get lost in the noise.

## Files touched

- `CLAUDE.md` — added discipline section + corrected items tree (`tome.ts`, `affix-ids.ts`, `templates/` as dir, `93` tests, added `sell-price` / `item-name` / `mod-i18n` / `equipment` / `lexicon`)
- `CONTEXT.md` — armor section rewritten Last-Epoch → PoE-style with historical pivot note
- `docs/codebase-map.md` — hooks (+6), world components (+7), convex (`admin.ts`, `_shared/`), `src/game/vendor/`, monsters scaling/modifiers, world travel + encounter-schedule, line counts
- `docs/plans/in-progress.md` — snapshot date, vitest count, world.tsx + useCombatLoop line counts, CONTEXT.md line count, CI-gate language, refreshed "Reading from fresh session" instructions
- `docs/playbooks/README.md` + `_examples/README.md` — "CI gate" → "Type-check gate" + local-only caveat
- `docs/security/threat-model.md` — Threat #3 marked CLOSED (PR #48 + #51), discrete-fixes table updated with status

## Test plan

- [x] `npx tsc --noEmit` — passes (sentinels still type-check, no stale type references introduced)
- [ ] Sanity scan of `CLAUDE.md` discipline section — read it cold, is each trigger row clear about which doc to update?
- [ ] Spot-check the armor rewrite in `CONTEXT.md` — does the historical note make the pivot self-explanatory to the next agent?
- [ ] Open `docs/codebase-map.md` and verify the hook / component / convex tables now match `src/hooks/`, `src/components/world/`, `convex/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)