### PR TITLE
refactor(classes): extract CLASS_NAME paraglide map to shared helper

### DIFF
--- a/docs/codebase-map.md
+++ b/docs/codebase-map.md
@@ -40,7 +40,7 @@ No React. No Convex. Same code runs on client and server (convex imports from he
 
 | Directory | What lives there | Key files |
 |---|---|---|
-| `classes/` | Character class definitions (Warrior/Rogue/Mage) | `data.ts` (CLASS_DEFINITIONS), `types.ts` |
+| `classes/` | Character class definitions (Warrior/Rogue/Mage) | `data.ts` (CLASS_DEFINITIONS), `types.ts`, `i18n.ts` (`getClassDisplayName`) |
 | `combat/` | Damage/defense math, constants | `damage.ts`, `barrier.ts`, `leech.ts`, `constants.ts` |
 | `i18n/` | Naming-lexicon primitives shared by all locales | `lexicon-shared.ts` (`GrammaticalGender`, `GenderedForm`, `pickGendered`) |
 | `inventory/` | Inventory constants + helpers | `constants.ts` (INVENTORY_MAX_SLOTS, bySlotAsc) |

--- a/docs/plans/in-progress.md
+++ b/docs/plans/in-progress.md
@@ -12,7 +12,7 @@ When a planned item starts, move it to a feature branch and reference back here.
 
 Both monolith refactors are done — world.tsx (PR #45) and useCombatLoop (PR #47, split into `useCombatLoop` + `useCombatTick` + `useEncounterSchedule`). Camp/phase derivation (PR #48), thorns-reflect fix (PR #49), spam-click in-flight tracking (PR #50), the phase-arg dead-weight cleanup (PR #51), the `useInFlight` extraction (PR #52), and the single-active-session lock (`feat/single-active-session`) all shipped. The leaderboard hard-blocker is now cleared.
 
-Pick the next item by readiness: **monster crit** (queued below — finally activates the build-pressure that the PoE-style armor formula assumes) is the highest-leverage gameplay debt; **native monster barrier** is mechanical; **CLASS_NAME helper extraction** is a 30-minute polish PR that retires four duplicate maps.
+Pick the next item by readiness: **monster crit** (queued below — finally activates the build-pressure that the PoE-style armor formula assumes) is the highest-leverage gameplay debt; **native monster barrier** is mechanical. The pure-refactor backlog is now empty — what remains is rebalance + features.
 
 ### world.tsx size — closed decision
 
@@ -346,49 +346,6 @@ Both are documented with severity, mechanism, and layered fixes in the threat-mo
 - Layer 3 (server-tick combat, days): competitive mode with real value at stake.
 
 When a session starts on this, read the threat-model doc first — it has the schema changes, acceptance criteria, and tradeoffs per layer.
-
----
-
-## Extract `CLASS_NAME` paraglide map to a shared helper (queued)
-
-**Status**: Planned, not started. Flagged by the simplify pass on the admin dashboard PR (#46) and deferred from that PR to avoid scope creep. Both agents that reviewed the admin diff (reuse + quality) called out this duplication as a real concern.
-
-**Why**: the same `Record<CharacterClassId, () => string>` paraglide-message map is inlined in **four** call sites today:
-
-- `src/routes/character-select.tsx:18-22`
-- `src/components/CreateCharacterModal.tsx:19-23`
-- `src/components/world/StatusCard.tsx:13-17`
-- `src/routes/admin/users.tsx:21-25` (added in PR #46)
-
-The comment at `src/game/classes/data.ts:5-6` already calls out that consumers maintain these maps — the codebase has been waiting for someone to extract the helper. Four copies is the tipping point: any future change to a class name (rename, new class, locale-specific tweak) has to touch four files and risks drift.
-
-### Scope
-
-- Add a new helper in `src/game/classes/i18n.ts` (matches the world/items locale-i18n shape) exporting:
-  ```ts
-  export function getClassDisplayName(classId: string): string {
-    const def = findClassDefinition(classId);
-    if (!def) return classId;
-    // CLASS_NAME map lives here, keyed by CharacterClassId, paraglide getters as values.
-    return CLASS_NAME[def.id]();
-  }
-  ```
-- Replace the inline `CLASS_NAME` + ad-hoc resolution in all four call sites with `getClassDisplayName(c.classId)`.
-- Remove the now-stale comment in `src/game/classes/data.ts` (the one that flags this duplication).
-
-### Watch out for
-
-- `src/routes/admin/users.tsx` (PR #46) wraps the call in a tiny `classDisplayName` helper that handles the unknown-class fallback. The shared helper should keep that fallback so the admin drill-down doesn't crash on a legacy character with a removed class id.
-- The three non-admin call sites currently use `m.unknown_class()` as the fallback, not the raw id. Check whether the shared helper should also fall back via paraglide (consistency) or return the raw id (admin behavior). Reasonable answer: paraglide fallback, since the admin row would also benefit from a translated "Unknown class" label.
-
-### Validation
-
-- `npx tsc --noEmit`, `npx vitest run`, `npx biome check`.
-- Manual: open character-select, the create-character modal (after picking each class), the world status card, and `/admin/users` (expand a row). Class names render in the active locale for every site.
-
-### Why deferred from PR #46
-
-PR #46 added one of the four duplicates as part of building the admin dashboard. Extracting in the same PR would have pulled `CreateCharacterModal.tsx` and `StatusCard.tsx` into the diff — files unrelated to admin work — bloating the review surface and conflicting with the in-flight `useCombatLoop` split work in adjacent areas. The extraction is small enough that a focused follow-up PR is the cleaner path.
 
 ---
 

--- a/src/components/CreateCharacterModal.tsx
+++ b/src/components/CreateCharacterModal.tsx
@@ -6,6 +6,7 @@ import { Button } from "#/components/ui/button";
 import { Input } from "#/components/ui/input";
 import { Label } from "#/components/ui/label";
 import { CLASS_DEFINITIONS } from "#/game/classes/data";
+import { getClassDisplayName } from "#/game/classes/i18n";
 import type { CharacterClassId } from "#/game/classes/types";
 import { convexErrorMessage } from "#/lib/convex-errors";
 import { m } from "#/paraglide/messages";
@@ -15,12 +16,6 @@ import type { Id } from "../../convex/_generated/dataModel";
 const MAX_NAME_LENGTH = 20;
 
 const CLASS_LIST: CharacterClassId[] = ["warrior", "rogue", "mage"];
-
-const CLASS_NAME: Record<CharacterClassId, () => string> = {
-	warrior: m.class_warrior_name,
-	rogue: m.class_rogue_name,
-	mage: m.class_mage_name,
-};
 
 const CLASS_DESCRIPTION: Record<CharacterClassId, () => string> = {
 	warrior: m.class_warrior_description,
@@ -136,7 +131,7 @@ export default function CreateCharacterModal({
 									}`}
 								>
 									<div className="display-title text-base uppercase tracking-wider text-white">
-										{CLASS_NAME[id]()}
+										{getClassDisplayName(id)}
 									</div>
 									<div className="mt-1 text-[10px] uppercase tracking-wider text-white/50">
 										{ATTRIBUTE_LABEL[CLASS_DEFINITIONS[id].primaryAttribute]()}

--- a/src/components/world/StatusCard.tsx
+++ b/src/components/world/StatusCard.tsx
@@ -1,24 +1,14 @@
 import { Button } from "#/components/ui/button";
 import Tooltip from "#/components/ui/tooltip";
-import type {
-	CharacterClassDefinition,
-	CharacterClassId,
-} from "#/game/classes/types";
+import { getClassDisplayName } from "#/game/classes/i18n";
 import { xpToNextLevel } from "#/game/progression/levels";
 import type { ComputedCharacterStats } from "#/game/stats/types";
 import { m } from "#/paraglide/messages";
 import type { Doc } from "../../../convex/_generated/dataModel";
 import HealthGlobe from "./HealthGlobe";
 
-const CLASS_NAME: Record<CharacterClassId, () => string> = {
-	warrior: m.class_warrior_name,
-	rogue: m.class_rogue_name,
-	mage: m.class_mage_name,
-};
-
 type Props = {
 	character: Doc<"characters">;
-	classDef: CharacterClassDefinition | null;
 	stats: ComputedCharacterStats;
 	hpOverride?: number;
 	barrierOverride?: number;
@@ -45,7 +35,6 @@ function estimateDps(stats: ComputedCharacterStats): number {
 
 export default function StatusCard({
 	character,
-	classDef,
 	stats,
 	hpOverride,
 	barrierOverride,
@@ -55,7 +44,7 @@ export default function StatusCard({
 	onUsePotion,
 	onUseTeleportStone,
 }: Props) {
-	const classResolved = classDef ? CLASS_NAME[classDef.id]() : "Unknown";
+	const classResolved = getClassDisplayName(character.classId);
 	const maxHp = stats.maxLife;
 	const hpServer = character.hpCurrent ?? maxHp;
 	const hp = hpOverride ?? hpServer;

--- a/src/game/classes/data.ts
+++ b/src/game/classes/data.ts
@@ -1,9 +1,6 @@
 import type { CharacterClassDefinition, CharacterClassId } from "./types";
 
 export const CLASS_DEFINITIONS = {
-	// `name` and `description` are canonical English fallbacks. UI components
-	// translate via paraglide messages keyed by class id (see ATTRIBUTE_LABEL /
-	// CLASS_NAME / CLASS_DESCRIPTION maps in the consumers).
 	warrior: {
 		id: "warrior",
 		name: "Warrior",

--- a/src/game/classes/i18n.ts
+++ b/src/game/classes/i18n.ts
@@ -1,0 +1,14 @@
+import { m } from "#/paraglide/messages";
+import { findClassDefinition } from "./data";
+import type { CharacterClassId } from "./types";
+
+const CLASS_NAME: Record<CharacterClassId, () => string> = {
+	warrior: m.class_warrior_name,
+	rogue: m.class_rogue_name,
+	mage: m.class_mage_name,
+};
+
+export function getClassDisplayName(classId: string): string {
+	const def = findClassDefinition(classId);
+	return def ? CLASS_NAME[def.id]() : m.unknown_class();
+}

--- a/src/routes/admin/users.tsx
+++ b/src/routes/admin/users.tsx
@@ -6,8 +6,7 @@ import type { FunctionReturnType } from "convex/server";
 import { useMemo, useState } from "react";
 import { toast } from "sonner";
 import { Button } from "#/components/ui/button";
-import { findClassDefinition } from "#/game/classes/data";
-import type { CharacterClassId } from "#/game/classes/types";
+import { getClassDisplayName } from "#/game/classes/i18n";
 import { useConfirmationModal } from "#/hooks/useConfirmationModal";
 import { convexErrorMessage } from "#/lib/convex-errors";
 import { formatDate } from "#/lib/format";
@@ -22,17 +21,6 @@ export const Route = createFileRoute("/admin/users")({
 });
 
 type UserRow = FunctionReturnType<typeof api.admin.listUsers>[number];
-
-const CLASS_NAME: Record<CharacterClassId, () => string> = {
-	warrior: m.class_warrior_name,
-	rogue: m.class_rogue_name,
-	mage: m.class_mage_name,
-};
-
-function classDisplayName(classId: string): string {
-	const def = findClassDefinition(classId);
-	return def ? CLASS_NAME[def.id]() : classId;
-}
 
 function AdminUsersPage() {
 	const { data: users } = useSuspenseQuery(
@@ -301,7 +289,7 @@ function UserCharacters({ authUserId }: { authUserId: string }) {
 						<tr key={c._id} className="border-b border-white/5 last:border-b-0">
 							<td className="px-3 py-1.5 text-white">{c.name}</td>
 							<td className="px-3 py-1.5 text-white/70">
-								{classDisplayName(c.classId)}
+								{getClassDisplayName(c.classId)}
 							</td>
 							<td className="px-3 py-1.5 text-right tabular-nums text-white">
 								{c.level}

--- a/src/routes/character-select.tsx
+++ b/src/routes/character-select.tsx
@@ -6,8 +6,7 @@ import { useState } from "react";
 import { toast } from "sonner";
 import CreateCharacterModal from "#/components/CreateCharacterModal";
 import { Button } from "#/components/ui/button";
-import { findClassDefinition } from "#/game/classes/data";
-import type { CharacterClassId } from "#/game/classes/types";
+import { getClassDisplayName } from "#/game/classes/i18n";
 import { useConfirmationModal } from "#/hooks/useConfirmationModal";
 import { useInFlight } from "#/hooks/useInFlight";
 import { useModal } from "#/hooks/useModal";
@@ -19,12 +18,6 @@ import { queueFlashToast } from "#/lib/flash-toast";
 import { m } from "#/paraglide/messages";
 import { api } from "../../convex/_generated/api";
 import type { Doc, Id } from "../../convex/_generated/dataModel";
-
-const CLASS_NAME: Record<CharacterClassId, () => string> = {
-	warrior: m.class_warrior_name,
-	rogue: m.class_rogue_name,
-	mage: m.class_mage_name,
-};
 
 export const Route = createFileRoute("/character-select")({
 	// Role check happens here so the page can render the admin button on the
@@ -221,8 +214,7 @@ function CharacterRow({
 	onSelect: () => void;
 	onDelete: () => void;
 }) {
-	const classDef = findClassDefinition(character.classId);
-	const className = classDef ? CLASS_NAME[classDef.id]() : m.unknown_class();
+	const className = getClassDisplayName(character.classId);
 
 	return (
 		<li

--- a/src/routes/world.tsx
+++ b/src/routes/world.tsx
@@ -729,7 +729,6 @@ function WorldLayout({ character }: { character: Doc<"characters"> }) {
 				/>
 				<StatusCard
 					character={character}
-					classDef={classDef}
 					stats={stats}
 					hpOverride={hpOverride}
 					barrierOverride={barrierOverride}


### PR DESCRIPTION
## Summary

- Centralizes the four duplicated `Record<CharacterClassId, () => string>` paraglide maps into `src/game/classes/i18n.ts` (`getClassDisplayName(classId)`). Closes the queued entry from `docs/plans/in-progress.md`.
- Fallback unified on `m.unknown_class()` across all four sites:
  - `StatusCard` previously fell back to the literal string `"Unknown"` (untranslated). Now translated.
  - `/admin/users` previously fell back to the raw `classId` string. Now translated.
- Drops the now-dead `classDef` prop on `StatusCard` and its `classDef={classDef}` arg in `world.tsx` (the only consumer of the prop was the replaced name resolution). The local `classDef` in `world.tsx` stays because `stats` still consumes it.
- Removes the stale comment in `src/game/classes/data.ts` that flagged the duplication.

Net diff: +24/-93. Docs in same PR: `codebase-map.md` cites the new file under `classes/`; `in-progress.md` entry removed; "next session" hint updated.

## Test plan

- [x] `npx tsc --noEmit` clean
- [x] `npx vitest run` — 525/525
- [x] `npx convex dev --once` clean
- [x] `npx biome check` clean on touched files
- [ ] Manual: open `/character-select`, `CreateCharacterModal` (per class), `/world` `StatusCard`, `/admin/users` (expand a row). Class names render in active locale on all four sites. Switch locale and confirm.
- [ ] Manual: trigger an "unknown class" path (legacy character with a removed classId, if any) — should show "Desconhecida"/"Unknown" not raw id.

🤖 Generated with [Claude Code](https://claude.com/claude-code)