### PR TITLE
fix: StatusCard reads combatState out of combat, barrier survives reload

### DIFF
--- a/src/routes/world.tsx
+++ b/src/routes/world.tsx
@@ -651,18 +651,20 @@ function WorldLayout({ character }: { character: Doc<"characters"> }) {
 		logMessage = m.inside_zone({ zone: translateNodeName(currentNode) });
 	}
 
-	const hpOverride = view === "combat" ? combat.playerHp : undefined;
+	const hpOverride = view === "combat" ? combat.playerHp : Math.min(hp, maxHp);
 
 	const [outOfCombatBarrier, setOutOfCombatBarrier] = useState<number | null>(
 		null,
 	);
 	const outOfCombatBarrierRef = useRef(makeBarrierState(stats.maxBarrier));
+	const combatStateLoaded = combatState !== undefined;
 
 	useEffect(() => {
 		if (view === "combat") {
 			setOutOfCombatBarrier(null);
 			return;
 		}
+		if (!combatStateLoaded) return;
 		const initial =
 			view === "city"
 				? stats.maxBarrier
@@ -674,7 +676,7 @@ function WorldLayout({ character }: { character: Doc<"characters"> }) {
 		};
 		outOfCombatBarrierRef.current = state;
 		setOutOfCombatBarrier(state.current);
-	}, [view, stats.maxBarrier]); // character.barrierCurrent excluded — one-time init per view switch
+	}, [view, stats.maxBarrier, combatStateLoaded]); // barrier excluded — read at init time only
 
 	const needsBarrierRegen =
 		view !== "combat" &&
@@ -708,7 +710,7 @@ function WorldLayout({ character }: { character: Doc<"characters"> }) {
 		view === "combat"
 			? combat.barrier.current
 			: (outOfCombatBarrier ?? barrier);
-	const potionsOverride = view === "combat" ? combat.potions : undefined;
+	const potionsOverride = view === "combat" ? combat.potions : potions;
 	// Pass the wrapped handler when allowed; when an in-flight call is
 	// pending, clear it so StatusCard's internal `canUsePotion` check disables
 	// its button without needing a new prop. CombatScene receives the handler


### PR DESCRIPTION
## Summary

Follow-up to #61. Three bugs surfaced after the combatState migration shipped:

- **HP not syncing in StatusCard out of combat** — `hpOverride` was `undefined` outside combat, so StatusCard fell back to `character.hpCurrent` which is no longer written by `syncHp` post-migration.
- **Barrier resets on browser reload** — `outOfCombatBarrier` init effect ran on first render before `combatState` query resolved, capturing stale `character.barrierCurrent`. Effect deps didn't re-fire when `combatState` loaded.
- **HP looks bugged after equipping items** — Same root cause as #1; equipping items that change `maxLife` exposed the stale-vs-truth discrepancy.

## Fixes

- Pass merged `hp` (clamped to `maxHp`) and `potions` as overrides always — not just during combat.
- Gate the `outOfCombatBarrier` init effect on `combatStateLoaded` so it waits for the query before initializing.

## Test plan

- [x] `npx tsc --noEmit` passes
- [ ] Manual: take damage, exit combat → StatusCard shows correct HP
- [ ] Manual: reload page mid-map → barrier shows persisted value, not max
- [ ] Manual: equip life-modifying item → HP bar reflects new percentage correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)